### PR TITLE
Prompt run robustness — Phase 1: schema + status backfill

### DIFF
--- a/app/controllers/completion_kit/runs_controller.rb
+++ b/app/controllers/completion_kit/runs_controller.rb
@@ -63,7 +63,7 @@ module CompletionKit
     end
 
     def generate
-      @run.update!(status: "generating", progress_current: 0, progress_total: 0, error_message: nil)
+      @run.update!(status: "running", progress_current: 0, progress_total: 0, error_message: nil)
       GenerateJob.perform_later(@run.id)
       redirect_to run_path(@run)
     end

--- a/app/helpers/completion_kit/application_helper.rb
+++ b/app/helpers/completion_kit/application_helper.rb
@@ -35,8 +35,6 @@ module CompletionKit
         "ck-badge ck-badge--pending"
       when "running"
         "ck-badge ck-badge--running"
-      when "generating", "judging"
-        "ck-badge ck-badge--running"
       when "completed"
         "ck-badge ck-badge--high"
       when "failed"
@@ -48,7 +46,7 @@ module CompletionKit
 
     def ck_run_dot(run)
       case run.status
-      when "generating", "judging" then "ck-dot ck-dot--running"
+      when "running" then "ck-dot ck-dot--running"
       when "failed" then "ck-dot ck-dot--failed"
       when "completed" then "ck-dot ck-dot--completed"
       else "ck-dot ck-dot--pending"
@@ -58,17 +56,11 @@ module CompletionKit
     def ck_run_status_label(run)
       case run.status
       when "pending" then "Ready to run"
-      when "generating"
+      when "running"
         if run.progress_total.to_i > 0
-          "Generating responses (#{run.progress_current}/#{run.progress_total})"
+          "Running (#{run.progress_current}/#{run.progress_total})"
         else
-          "Generating responses…"
-        end
-      when "judging"
-        if run.progress_total.to_i > 0
-          "Judging (#{run.progress_current}/#{run.progress_total} evaluations)"
-        else
-          "Judging…"
+          "Running…"
         end
       when "completed" then "Completed"
       when "failed" then "Failed"

--- a/app/models/completion_kit/response.rb
+++ b/app/models/completion_kit/response.rb
@@ -1,18 +1,30 @@
 module CompletionKit
   class Response < ApplicationRecord
+    STATUSES = %w[pending retrying succeeded failed].freeze
+    TERMINAL_STATUSES = %w[succeeded failed].freeze
+
     belongs_to :run
     has_many :reviews, dependent: :destroy
 
     delegate :prompt, to: :run
 
-    validates :response_text, presence: true
+    validates :response_text, presence: true, if: :requires_response_text?
+    validates :status, inclusion: { in: STATUSES }
+
+    before_validation :set_default_status, on: :create
+
+    def terminal?
+      TERMINAL_STATUSES.include?(status)
+    end
 
     def as_json(options = {})
       {
         id: id, run_id: run_id, input_data: input_data,
         response_text: response_text, expected_output: expected_output,
         created_at: created_at, score: score, reviewed: reviewed?,
-        reviews: reviews.map(&:as_json)
+        reviews: reviews.map(&:as_json),
+        status: status, attempts: attempts, row_index: row_index,
+        error: error_payload
       }
     end
 
@@ -25,6 +37,21 @@ module CompletionKit
 
     def reviewed?
       reviews.any? { |r| r.ai_score.present? }
+    end
+
+    def error_payload
+      return nil if error_class.blank?
+      { provider: error_provider, class: error_class, status: error_status, message: error_message }
+    end
+
+    private
+
+    def set_default_status
+      self.status ||= "pending"
+    end
+
+    def requires_response_text?
+      status == "succeeded"
     end
   end
 end

--- a/app/models/completion_kit/response.rb
+++ b/app/models/completion_kit/response.rb
@@ -8,13 +8,17 @@ module CompletionKit
 
     delegate :prompt, to: :run
 
-    validates :response_text, presence: true, if: :requires_response_text?
+    validates :response_text, presence: true, if: :succeeded?
     validates :status, inclusion: { in: STATUSES }
 
     before_validation :set_default_status, on: :create
 
     def terminal?
       TERMINAL_STATUSES.include?(status)
+    end
+
+    def succeeded?
+      status == "succeeded"
     end
 
     def as_json(options = {})
@@ -48,10 +52,6 @@ module CompletionKit
 
     def set_default_status
       self.status ||= "pending"
-    end
-
-    def requires_response_text?
-      status == "succeeded"
     end
   end
 end

--- a/app/models/completion_kit/review.rb
+++ b/app/models/completion_kit/review.rb
@@ -1,6 +1,7 @@
 module CompletionKit
   class Review < ApplicationRecord
-    STATUSES = %w[pending evaluated failed].freeze
+    STATUSES = %w[pending retrying succeeded failed].freeze
+    TERMINAL_STATUSES = %w[succeeded failed].freeze
 
     belongs_to :response
     belongs_to :metric, optional: true
@@ -11,11 +12,25 @@ module CompletionKit
 
     before_validation :set_default_status
 
+    def terminal?
+      TERMINAL_STATUSES.include?(status)
+    end
+
+    def succeeded?
+      status == "succeeded"
+    end
+
+    def error_payload
+      return nil if error_class.blank?
+      { provider: error_provider, class: error_class, status: error_status, message: error_message }
+    end
+
     def as_json(options = {})
       {
         id: id, response_id: response_id, metric_id: metric_id,
         metric_name: metric_name, ai_score: ai_score,
-        ai_feedback: ai_feedback, status: status
+        ai_feedback: ai_feedback, status: status, attempts: attempts,
+        error: error_payload
       }
     end
 

--- a/app/models/completion_kit/run.rb
+++ b/app/models/completion_kit/run.rb
@@ -2,7 +2,7 @@ module CompletionKit
   class Run < ApplicationRecord
     include Turbo::Broadcastable
 
-    STATUSES = %w[pending generating judging completed failed].freeze
+    STATUSES = %w[pending running completed failed].freeze
 
     belongs_to :prompt
     belongs_to :dataset, optional: true
@@ -66,7 +66,7 @@ module CompletionKit
         return false
       end
 
-      update!(status: "generating", progress_current: 0, progress_total: rows.length, error_message: nil)
+      update!(status: "running", progress_current: 0, progress_total: rows.length, error_message: nil)
       responses.destroy_all
       broadcast_ui
       broadcast_clear_responses
@@ -109,7 +109,7 @@ module CompletionKit
 
     def judge_responses!
       total_evaluations = responses.count * metrics.count
-      update!(status: "judging", progress_current: 0, progress_total: total_evaluations, error_message: nil)
+      update!(status: "running", progress_current: 0, progress_total: total_evaluations, error_message: nil)
       broadcast_ui
 
       judge = JudgeService.new(ApiConfig.for_model(judge_model).merge(judge_model: judge_model))

--- a/app/models/completion_kit/run.rb
+++ b/app/models/completion_kit/run.rb
@@ -130,7 +130,7 @@ module CompletionKit
             review.assign_attributes(
               metric_name: metric.name,
               instruction: metric.instruction.to_s,
-              status: "evaluated",
+              status: "succeeded",
               ai_score: evaluation[:score],
               ai_feedback: evaluation[:feedback]
             )

--- a/app/views/completion_kit/runs/_actions.html.erb
+++ b/app/views/completion_kit/runs/_actions.html.erb
@@ -1,5 +1,5 @@
 <div class="ck-actions" id="run_actions">
-  <% running = run.status == "generating" || run.status == "judging" %>
+  <% running = run.status == "running" %>
   <%= button_to run_path(run), method: :delete, form_class: "inline-block", class: "ck-icon-btn", title: "Delete run", "aria-label": "Delete run", disabled: running, data: { turbo_confirm: "Delete this run and all its responses?" } do %><%= heroicon_tag "trash", variant: :outline, size: 16, "aria-hidden": "true" %><% end %>
   <% if running %>
     <%= link_to "Edit", edit_run_path(run), class: ck_button_classes(:light, variant: :outline) + " disabled", "aria-disabled": "true", tabindex: "-1" %>

--- a/app/views/completion_kit/runs/_progress.html.erb
+++ b/app/views/completion_kit/runs/_progress.html.erb
@@ -1,5 +1,5 @@
 <div id="run_progress">
-  <% if run.status == "generating" || run.status == "judging" %>
+  <% if run.status == "running" %>
     <div class="ck-discovery-bar">
       <div class="ck-discovery-bar__label">
         <%= ck_run_status_label(run) %>

--- a/app/views/completion_kit/runs/_response_row.html.erb
+++ b/app/views/completion_kit/runs/_response_row.html.erb
@@ -6,8 +6,8 @@
       <span class="ck-score"><span class="ck-score__star">★</span> <%= response.score %></span>
     <% elsif run.status == "failed" %>
       <span class="ck-chip">Failed</span>
-    <% elsif run.status == "judging" %>
-      <span class="ck-chip">Judging</span>
+    <% elsif run.status == "running" %>
+      <span class="ck-chip">Running</span>
     <% end %>
   </span>
 <% end %>

--- a/db/migrate/20260501000001_add_status_and_error_to_responses.rb
+++ b/db/migrate/20260501000001_add_status_and_error_to_responses.rb
@@ -1,0 +1,22 @@
+class AddStatusAndErrorToResponses < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_responses, :status, :string, default: "pending", null: false
+    add_column :completion_kit_responses, :error_provider, :string
+    add_column :completion_kit_responses, :error_class, :string
+    add_column :completion_kit_responses, :error_status, :integer
+    add_column :completion_kit_responses, :error_message, :text
+    add_column :completion_kit_responses, :attempts, :integer, default: 0, null: false
+    add_column :completion_kit_responses, :row_index, :integer
+    add_index  :completion_kit_responses, [:run_id, :status]
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_responses
+          SET status = 'succeeded'
+          WHERE response_text IS NOT NULL AND length(response_text) > 0
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20260501000001_add_status_and_error_to_responses.rb
+++ b/db/migrate/20260501000001_add_status_and_error_to_responses.rb
@@ -7,7 +7,6 @@ class AddStatusAndErrorToResponses < ActiveRecord::Migration[7.1]
     add_column :completion_kit_responses, :error_message, :text
     add_column :completion_kit_responses, :attempts, :integer, default: 0, null: false
     add_column :completion_kit_responses, :row_index, :integer
-    add_index  :completion_kit_responses, [:run_id, :status]
 
     reversible do |dir|
       dir.up do

--- a/db/migrate/20260501000002_index_responses_on_run_id_and_status.rb
+++ b/db/migrate/20260501000002_index_responses_on_run_id_and_status.rb
@@ -1,0 +1,9 @@
+class IndexResponsesOnRunIdAndStatus < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :completion_kit_responses, [:run_id, :status],
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/migrate/20260501000003_add_status_and_error_to_reviews.rb
+++ b/db/migrate/20260501000003_add_status_and_error_to_reviews.rb
@@ -1,0 +1,25 @@
+class AddStatusAndErrorToReviews < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_reviews, :error_provider, :string
+    add_column :completion_kit_reviews, :error_class, :string
+    add_column :completion_kit_reviews, :error_status, :integer
+    add_column :completion_kit_reviews, :error_message, :text
+    add_column :completion_kit_reviews, :attempts, :integer, default: 0, null: false
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_reviews
+          SET status = 'succeeded'
+          WHERE ai_score IS NOT NULL
+        SQL
+
+        execute <<~SQL
+          UPDATE completion_kit_reviews
+          SET status = 'succeeded'
+          WHERE status = 'evaluated'
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20260501000004_index_reviews_on_response_id_and_status.rb
+++ b/db/migrate/20260501000004_index_reviews_on_response_id_and_status.rb
@@ -1,0 +1,9 @@
+class IndexReviewsOnResponseIdAndStatus < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :completion_kit_reviews, [:response_id, :status],
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/migrate/20260501000005_collapse_run_status_and_add_failure_summary.rb
+++ b/db/migrate/20260501000005_collapse_run_status_and_add_failure_summary.rb
@@ -1,0 +1,15 @@
+class CollapseRunStatusAndAddFailureSummary < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_runs, :failure_summary, :string
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_runs
+          SET status = 'running'
+          WHERE status IN ('generating', 'judging')
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20260501000005_collapse_run_status_and_add_failure_summary.rb
+++ b/db/migrate/20260501000005_collapse_run_status_and_add_failure_summary.rb
@@ -1,6 +1,6 @@
 class CollapseRunStatusAndAddFailureSummary < ActiveRecord::Migration[7.1]
   def change
-    add_column :completion_kit_runs, :failure_summary, :string
+    add_column :completion_kit_runs, :failure_summary, :text
 
     reversible do |dir|
       dir.up do

--- a/docs/superpowers/plans/2026-05-03-prompt-run-robustness.md
+++ b/docs/superpowers/plans/2026-05-03-prompt-run-robustness.md
@@ -267,7 +267,6 @@ class AddStatusAndErrorToReviews < ActiveRecord::Migration[7.1]
     add_column :completion_kit_reviews, :error_status, :integer
     add_column :completion_kit_reviews, :error_message, :text
     add_column :completion_kit_reviews, :attempts, :integer, default: 0, null: false
-    add_index  :completion_kit_reviews, [:response_id, :status]
 
     reversible do |dir|
       dir.up do
@@ -283,6 +282,24 @@ end
 ```
 
 (The `status` column already exists on reviews — the existing `STATUSES` was `pending evaluated failed`. We are renaming `evaluated` → `succeeded` for consistency and adding `retrying`.)
+
+- [ ] **Step 2b: Create the concurrent index migration**
+
+Create a second migration `db/migrate/<timestamp+1>_index_reviews_on_response_id_and_status.rb`:
+
+```ruby
+class IndexReviewsOnResponseIdAndStatus < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :completion_kit_reviews, [:response_id, :status],
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end
+```
+
+Same reasoning as Task 1: `add_index` on Postgres takes `ACCESS EXCLUSIVE` and blocks reads/writes; concurrent index needs its own non-transactional migration.
 
 - [ ] **Step 3: Backfill the existing `evaluated` rows in the migration too**
 

--- a/docs/superpowers/plans/2026-05-03-prompt-run-robustness.md
+++ b/docs/superpowers/plans/2026-05-03-prompt-run-robustness.md
@@ -102,7 +102,8 @@ Append to `spec/models/completion_kit/response_spec.rb`:
 RSpec.describe CompletionKit::Response, type: :model do
   describe "status" do
     it "defaults to pending on a new record" do
-      response = build(:completion_kit_response, response_text: "anything")
+      response = build(:completion_kit_response, status: nil, response_text: "anything")
+      response.valid?
       expect(response.status).to eq("pending")
     end
 

--- a/docs/superpowers/plans/2026-05-03-prompt-run-robustness.md
+++ b/docs/superpowers/plans/2026-05-03-prompt-run-robustness.md
@@ -1,0 +1,2332 @@
+# Prompt Run Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch from `:async` to Solid Queue, fan out each prompt run into per-row LLM jobs that retry independently, surface provider failures clearly, and let users retry only the failed rows.
+
+**Architecture:** Engine ships row-level jobs (`GenerateRowJob`, `JudgeReviewJob`, `RunCompletionCheckJob`) with Solid Queue concurrency keys (per-provider + per-run). Generation and judging interleave — each `GenerateRowJob` enqueues its own `JudgeReviewJob`s on success. Run completion is detected by a tiny check job serialized through a per-run concurrency lock. UI status header shows two counters; failed rows surface provider-named badges with a per-run "retry failed rows" action.
+
+**Tech Stack:** Rails 7 engine, Solid Queue (Active Job adapter), Turbo Streams, RSpec + FactoryBot, SQLite for tests / Postgres (Supabase) for prod.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md`
+
+---
+
+## Conventions used in every task
+
+- **Test path mirrors source path.** A model at `app/models/completion_kit/foo.rb` has its spec at `spec/models/completion_kit/foo_spec.rb`. A job at `app/jobs/completion_kit/foo_job.rb` has its spec at `spec/jobs/completion_kit/foo_job_spec.rb`.
+- **Test database is in-memory SQLite** — its schema is hand-written in `spec/rails_helper.rb` (lines ~40–170). Any column added to a real migration MUST also be added to that schema or the spec database won't have it.
+- **Run-spec broadcasts are stubbed** at the top of `spec/models/completion_kit/run_spec.rb` to avoid Action Cable noise. Follow the same pattern for any spec that exercises a method that broadcasts.
+- **Factories** live in `spec/factories/`, named `completion_kit_<model>`, e.g. `create(:completion_kit_run)`.
+- **Run all specs:** `bundle exec rspec`. Run one file: `bundle exec rspec spec/models/completion_kit/run_spec.rb`. Run one example: append `:LINE`.
+- **No comments in code** (project-wide rule from `CLAUDE.md`). The plan never asks you to add code comments.
+- **Commit messages** are subject-line only or subject + one short sentence. No multi-paragraph bodies. Do not include AI attribution.
+
+---
+
+# Phase 1 (PR 1): Schema + status backfill
+
+> Goal of this PR: land all schema additions and backfill existing rows to terminal states. No behavior change. Safe to ship to web alone.
+
+---
+
+### Task 1: Add status + error columns to completion_kit_responses
+
+**Files:**
+- Create: `db/migrate/<timestamp>_add_status_and_error_to_responses.rb`
+- Modify: `spec/rails_helper.rb` (in-memory schema, find the `create_table :completion_kit_responses` block ~line 119)
+- Modify: `app/models/completion_kit/response.rb`
+- Modify: `spec/factories/responses.rb`
+- Test: `spec/models/completion_kit/response_spec.rb`
+
+- [ ] **Step 1: Generate the engine migration**
+
+Run: `bundle exec rails g migration AddStatusAndErrorToResponses --no-test-framework`
+
+This creates a file under `db/migrate/`. Rename the timestamp portion to today's date if needed.
+
+- [ ] **Step 2: Fill the migration**
+
+```ruby
+class AddStatusAndErrorToResponses < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_responses, :status, :string, default: "pending", null: false
+    add_column :completion_kit_responses, :error_provider, :string
+    add_column :completion_kit_responses, :error_class, :string
+    add_column :completion_kit_responses, :error_status, :integer
+    add_column :completion_kit_responses, :error_message, :text
+    add_column :completion_kit_responses, :attempts, :integer, default: 0, null: false
+    add_column :completion_kit_responses, :row_index, :integer
+    add_index  :completion_kit_responses, [:run_id, :status]
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_responses
+          SET status = 'succeeded'
+          WHERE response_text IS NOT NULL AND length(response_text) > 0
+        SQL
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Mirror the columns in the in-memory test schema**
+
+In `spec/rails_helper.rb`, find the `create_table :completion_kit_responses` block and add the columns:
+
+```ruby
+create_table :completion_kit_responses, force: true do |t|
+  t.references :run, null: false
+  t.text :input_data
+  t.text :response_text
+  t.text :expected_output
+  t.string :status, default: "pending", null: false
+  t.string :error_provider
+  t.string :error_class
+  t.integer :error_status
+  t.text :error_message
+  t.integer :attempts, default: 0, null: false
+  t.integer :row_index
+  t.index [:run_id, :status]
+  t.timestamps
+end
+```
+
+- [ ] **Step 4: Write a failing test for the Response status enum + terminal? predicate**
+
+Append to `spec/models/completion_kit/response_spec.rb`:
+
+```ruby
+RSpec.describe CompletionKit::Response, type: :model do
+  describe "status" do
+    it "defaults to pending on a new record" do
+      response = build(:completion_kit_response, response_text: "anything")
+      expect(response.status).to eq("pending")
+    end
+
+    it "validates inclusion in the STATUSES list" do
+      response = build(:completion_kit_response, status: "weird")
+      expect(response).not_to be_valid
+      expect(response.errors[:status]).to be_present
+    end
+
+    %w[pending retrying].each do |status|
+      it "is not terminal? when status is #{status}" do
+        expect(build(:completion_kit_response, status: status)).not_to be_terminal
+      end
+    end
+
+    %w[succeeded failed].each do |status|
+      it "is terminal? when status is #{status}" do
+        expect(build(:completion_kit_response, status: status)).to be_terminal
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run tests — confirm they fail**
+
+Run: `bundle exec rspec spec/models/completion_kit/response_spec.rb`
+Expected: failures on the new examples (`status` returns nil OR predicate `terminal?` undefined).
+
+- [ ] **Step 6: Implement the validation and predicate on the model**
+
+In `app/models/completion_kit/response.rb`:
+
+```ruby
+module CompletionKit
+  class Response < ApplicationRecord
+    STATUSES = %w[pending retrying succeeded failed].freeze
+    TERMINAL_STATUSES = %w[succeeded failed].freeze
+
+    belongs_to :run
+    has_many :reviews, dependent: :destroy
+
+    delegate :prompt, to: :run
+
+    validates :response_text, presence: true, if: :requires_response_text?
+    validates :status, inclusion: { in: STATUSES }
+
+    before_validation :set_default_status, on: :create
+
+    def terminal?
+      TERMINAL_STATUSES.include?(status)
+    end
+
+    def as_json(options = {})
+      {
+        id: id, run_id: run_id, input_data: input_data,
+        response_text: response_text, expected_output: expected_output,
+        created_at: created_at, score: score, reviewed: reviewed?,
+        reviews: reviews.map(&:as_json),
+        status: status, attempts: attempts, row_index: row_index,
+        error: error_payload
+      }
+    end
+
+    def score
+      scores = reviews.select { |r| r.ai_score.present? }.map { |r| r.ai_score.to_f }
+      return nil if scores.empty?
+
+      (scores.sum / scores.length).round(2)
+    end
+
+    def reviewed?
+      reviews.any? { |r| r.ai_score.present? }
+    end
+
+    def error_payload
+      return nil if error_class.blank?
+      { provider: error_provider, class: error_class, status: error_status, message: error_message }
+    end
+
+    private
+
+    def set_default_status
+      self.status ||= "pending"
+    end
+
+    def requires_response_text?
+      status == "succeeded"
+    end
+  end
+end
+```
+
+- [ ] **Step 7: Update the response factory so existing tests still pass**
+
+In `spec/factories/responses.rb`:
+
+```ruby
+FactoryBot.define do
+  factory :completion_kit_response, class: "CompletionKit::Response" do
+    association :run, factory: :completion_kit_run
+    input_data { { content: "Release notes", audience: "developers" }.to_json }
+    response_text { "A generated summary" }
+    expected_output { "A developer-focused summary" }
+    status { "succeeded" }
+
+    trait :pending do
+      status { "pending" }
+      response_text { nil }
+    end
+
+    trait :failed do
+      status { "failed" }
+      response_text { nil }
+      error_provider { "openai" }
+      error_class { "Faraday::TimeoutError" }
+      error_status { nil }
+      error_message { "execution expired" }
+      attempts { 5 }
+    end
+  end
+end
+```
+
+(The default `status: "succeeded"` keeps existing specs that don't care about status passing because `response_text` is also present.)
+
+- [ ] **Step 8: Run tests — confirm green**
+
+Run: `bundle exec rspec spec/models/completion_kit/response_spec.rb`
+Expected: all examples pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add db/migrate spec/rails_helper.rb app/models/completion_kit/response.rb spec/factories/responses.rb spec/models/completion_kit/response_spec.rb
+git commit -m "add status and error columns to responses"
+```
+
+---
+
+### Task 2: Add status + error columns to completion_kit_reviews
+
+**Files:**
+- Create: `db/migrate/<timestamp>_add_status_and_error_to_reviews.rb`
+- Modify: `spec/rails_helper.rb` (the `create_table :completion_kit_reviews` block ~line 132)
+- Modify: `app/models/completion_kit/review.rb`
+- Modify: `spec/factories/reviews.rb`
+- Test: `spec/models/completion_kit/review_spec.rb` (create if missing)
+
+- [ ] **Step 1: Generate the migration**
+
+Run: `bundle exec rails g migration AddStatusAndErrorToReviews --no-test-framework`
+
+- [ ] **Step 2: Fill the migration**
+
+```ruby
+class AddStatusAndErrorToReviews < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_reviews, :error_provider, :string
+    add_column :completion_kit_reviews, :error_class, :string
+    add_column :completion_kit_reviews, :error_status, :integer
+    add_column :completion_kit_reviews, :error_message, :text
+    add_column :completion_kit_reviews, :attempts, :integer, default: 0, null: false
+    add_index  :completion_kit_reviews, [:response_id, :status]
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_reviews
+          SET status = 'succeeded'
+          WHERE ai_score IS NOT NULL
+        SQL
+      end
+    end
+  end
+end
+```
+
+(The `status` column already exists on reviews — the existing `STATUSES` was `pending evaluated failed`. We are renaming `evaluated` → `succeeded` for consistency and adding `retrying`.)
+
+- [ ] **Step 3: Backfill the existing `evaluated` rows in the migration too**
+
+Append to the `dir.up` block:
+
+```ruby
+execute <<~SQL
+  UPDATE completion_kit_reviews
+  SET status = 'succeeded'
+  WHERE status = 'evaluated'
+SQL
+```
+
+- [ ] **Step 4: Mirror new columns in the in-memory schema**
+
+In `spec/rails_helper.rb`, find the `create_table :completion_kit_reviews` block and add the new columns:
+
+```ruby
+create_table :completion_kit_reviews, force: true do |t|
+  t.references :response, null: false
+  t.references :metric
+  t.string :metric_name
+  t.text :instruction
+  t.string :status
+  t.decimal :ai_score, precision: 4, scale: 1
+  t.text :ai_feedback
+  t.string :error_provider
+  t.string :error_class
+  t.integer :error_status
+  t.text :error_message
+  t.integer :attempts, default: 0, null: false
+  t.index [:response_id, :status]
+  t.timestamps
+end
+```
+
+- [ ] **Step 5: Write failing test for new STATUSES + terminal?**
+
+Create `spec/models/completion_kit/review_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe CompletionKit::Review, type: :model do
+  describe "status" do
+    let(:response) { create(:completion_kit_response) }
+
+    it "validates inclusion in pending/retrying/succeeded/failed" do
+      review = build(:completion_kit_review, response: response, status: "evaluated")
+      expect(review).not_to be_valid
+    end
+
+    %w[pending retrying].each do |status|
+      it "is not terminal? when status is #{status}" do
+        expect(build(:completion_kit_review, response: response, status: status)).not_to be_terminal
+      end
+    end
+
+    %w[succeeded failed].each do |status|
+      it "is terminal? when status is #{status}" do
+        expect(build(:completion_kit_review, response: response, status: status)).to be_terminal
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 6: Run tests — confirm they fail**
+
+Run: `bundle exec rspec spec/models/completion_kit/review_spec.rb`
+Expected: failures (no `terminal?` method, `evaluated` still accepted).
+
+- [ ] **Step 7: Update the Review model**
+
+In `app/models/completion_kit/review.rb`:
+
+```ruby
+module CompletionKit
+  class Review < ApplicationRecord
+    STATUSES = %w[pending retrying succeeded failed].freeze
+    TERMINAL_STATUSES = %w[succeeded failed].freeze
+
+    belongs_to :response
+    belongs_to :metric, optional: true
+
+    validates :metric_name, presence: true
+    validates :status, inclusion: { in: STATUSES }
+    validates :ai_score, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }, allow_nil: true
+
+    before_validation :set_default_status
+
+    def terminal?
+      TERMINAL_STATUSES.include?(status)
+    end
+
+    def error_payload
+      return nil if error_class.blank?
+      { provider: error_provider, class: error_class, status: error_status, message: error_message }
+    end
+
+    def as_json(options = {})
+      {
+        id: id, response_id: response_id, metric_id: metric_id,
+        metric_name: metric_name, ai_score: ai_score,
+        ai_feedback: ai_feedback, status: status, attempts: attempts,
+        error: error_payload
+      }
+    end
+
+    private
+
+    def set_default_status
+      self.status ||= "pending"
+    end
+  end
+end
+```
+
+- [ ] **Step 8: Update the review factory**
+
+In `spec/factories/reviews.rb`, replace the contents with:
+
+```ruby
+FactoryBot.define do
+  factory :completion_kit_review, class: "CompletionKit::Review" do
+    association :response, factory: :completion_kit_response
+    association :metric, factory: :completion_kit_metric
+    metric_name { "Quality" }
+    instruction { "Rate the response quality." }
+    status { "succeeded" }
+    ai_score { 4.0 }
+    ai_feedback { "Good response." }
+  end
+end
+```
+
+- [ ] **Step 9: Find anywhere in the codebase that writes `status: "evaluated"` and update**
+
+Run: `grep -rn '"evaluated"' app/ spec/`
+
+In `app/models/completion_kit/run.rb` `judge_responses!` method (around line 132–138), change the `status: "evaluated"` literal in the `assign_attributes` block to `status: "succeeded"`. (This method will be replaced entirely in Phase 2 but must not break in the interim.)
+
+- [ ] **Step 10: Run tests — confirm green**
+
+Run: `bundle exec rspec spec/models/completion_kit/review_spec.rb spec/models/completion_kit/run_spec.rb`
+Expected: all examples pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add db/migrate spec/rails_helper.rb app/models/completion_kit/review.rb app/models/completion_kit/run.rb spec/factories/reviews.rb spec/models/completion_kit/review_spec.rb
+git commit -m "add error columns to reviews and unify status to succeeded"
+```
+
+---
+
+### Task 3: Collapse Run status enum and add failure_summary
+
+**Files:**
+- Create: `db/migrate/<timestamp>_collapse_run_status_and_add_failure_summary.rb`
+- Modify: `spec/rails_helper.rb` (the `create_table :completion_kit_runs` block ~line 96)
+- Modify: `app/models/completion_kit/run.rb`
+- Test: `spec/models/completion_kit/run_spec.rb`
+
+- [ ] **Step 1: Generate the migration**
+
+Run: `bundle exec rails g migration CollapseRunStatusAndAddFailureSummary --no-test-framework`
+
+- [ ] **Step 2: Fill the migration**
+
+```ruby
+class CollapseRunStatusAndAddFailureSummary < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_runs, :failure_summary, :string
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_runs
+          SET status = 'running'
+          WHERE status IN ('generating', 'judging')
+        SQL
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Mirror failure_summary in the in-memory schema**
+
+In `spec/rails_helper.rb`, in the `create_table :completion_kit_runs` block, add `t.string :failure_summary`.
+
+- [ ] **Step 4: Write failing test for the collapsed enum**
+
+In `spec/models/completion_kit/run_spec.rb`, append:
+
+```ruby
+describe "status enum" do
+  it "rejects the legacy generating status" do
+    run = build(:completion_kit_run, status: "generating")
+    expect(run).not_to be_valid
+  end
+
+  it "rejects the legacy judging status" do
+    run = build(:completion_kit_run, status: "judging")
+    expect(run).not_to be_valid
+  end
+
+  it "accepts running" do
+    run = build(:completion_kit_run, status: "running")
+    expect(run).to be_valid
+  end
+end
+```
+
+- [ ] **Step 5: Run tests — confirm they fail**
+
+Run: `bundle exec rspec spec/models/completion_kit/run_spec.rb -e "status enum"`
+Expected: examples fail (current STATUSES still includes generating/judging).
+
+- [ ] **Step 6: Update STATUSES on Run**
+
+In `app/models/completion_kit/run.rb`:
+
+```ruby
+STATUSES = %w[pending running completed failed].freeze
+```
+
+(Leave the existing `generate_responses!` / `judge_responses!` methods alone for now — they will be rewritten in Phase 2. Their `update!(status: "generating", ...)` and `update!(status: "judging", ...)` calls will fail validation, but that is intentional: those code paths must not be invoked between this PR and the Phase 2 PR. The `:async` adapter is still in effect, so existing controller actions still call those methods.)
+
+To avoid breaking the existing flow during the in-between window, change the literal status writes in `generate_responses!` and `judge_responses!` to write `"running"` instead of `"generating"` or `"judging"`. The methods otherwise stay intact:
+
+```ruby
+update!(status: "running", progress_current: 0, progress_total: rows.length, error_message: nil)
+```
+
+```ruby
+update!(status: "running", progress_current: 0, progress_total: total_evaluations, error_message: nil)
+```
+
+- [ ] **Step 7: Run the existing run spec**
+
+Run: `bundle exec rspec spec/models/completion_kit/run_spec.rb`
+Expected: all green. (Any spec that expected status "generating"/"judging" must be updated to expect "running".)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add db/migrate spec/rails_helper.rb app/models/completion_kit/run.rb spec/models/completion_kit/run_spec.rb
+git commit -m "collapse run status to pending/running/completed/failed"
+```
+
+---
+
+### Task 4: Install engine migrations into the standalone app
+
+**Files:**
+- Run rake task that copies engine migrations into `standalone/db/migrate/`
+
+- [ ] **Step 1: Install engine migrations**
+
+Run: `cd standalone && bin/rails completion_kit:install:migrations`
+
+This copies the three new migrations from `db/migrate/` into `standalone/db/migrate/<timestamp>_*.completion_kit.rb`.
+
+- [ ] **Step 2: Run them locally**
+
+Run: `cd standalone && bin/rails db:migrate`
+
+- [ ] **Step 3: Confirm schema.rb updated**
+
+Run: `git diff standalone/db/schema.rb`
+
+You should see the new columns on `completion_kit_responses`, `completion_kit_reviews`, `completion_kit_runs`.
+
+- [ ] **Step 4: Commit the installed migrations + schema change**
+
+```bash
+git add standalone/db/migrate standalone/db/schema.rb
+git commit -m "install schema migrations into standalone"
+```
+
+> **PR 1 ends here.** Open the PR with the four task commits. CI must be green. After merge, Render's pre-deploy `db:migrate` runs the migrations on Supabase. No behavior change yet.
+
+---
+
+# Phase 2 (PR 2): Adapter switch + new jobs
+
+> Goal of this PR: install Solid Queue, replace the monolithic generation/judging methods with row-level jobs, and switch the queue adapter. **The Render Worker service must exist before merging this PR** — the `:async` adapter goes away the moment this ships.
+
+---
+
+### Task 5: Add solid_queue gem to standalone
+
+**Files:**
+- Modify: `standalone/Gemfile`
+
+- [ ] **Step 1: Add the gem**
+
+In `standalone/Gemfile`, after `gem "completion-kit", path: "../"`:
+
+```ruby
+gem "solid_queue"
+gem "mission_control-jobs"
+```
+
+- [ ] **Step 2: Install**
+
+Run: `cd standalone && bundle install`
+
+- [ ] **Step 3: Verify the gems landed in the lockfile**
+
+Run: `grep -E "(solid_queue|mission_control-jobs) " standalone/Gemfile.lock`
+Expected: both names appear with versions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add standalone/Gemfile standalone/Gemfile.lock
+git commit -m "install solid_queue and mission_control-jobs in standalone"
+```
+
+---
+
+### Task 6: Add config/queue.yml in the standalone
+
+**Files:**
+- Create: `standalone/config/queue.yml`
+
+- [ ] **Step 1: Write the config**
+
+Create `standalone/config/queue.yml`:
+
+```yaml
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: [llm, default]
+      threads: <%= ENV.fetch("SOLID_QUEUE_THREADS", 10) %>
+      processes: <%= ENV.fetch("SOLID_QUEUE_PROCESSES", 1) %>
+      polling_interval: 0.5
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add standalone/config/queue.yml
+git commit -m "add solid_queue worker config"
+```
+
+---
+
+### Task 7: Add Prompt#llm_model_provider helper
+
+**Files:**
+- Modify: `app/models/completion_kit/prompt.rb`
+- Modify: `spec/models/completion_kit/prompt_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/models/completion_kit/prompt_spec.rb`:
+
+```ruby
+describe "#llm_model_provider" do
+  it "returns openai for a gpt-4 model" do
+    prompt = build(:completion_kit_prompt, llm_model: "gpt-4o")
+    expect(prompt.llm_model_provider).to eq("openai")
+  end
+
+  it "returns anthropic for a claude-3 model" do
+    prompt = build(:completion_kit_prompt, llm_model: "claude-3-5-sonnet-20241022")
+    expect(prompt.llm_model_provider).to eq("anthropic")
+  end
+
+  it "returns nil for an unknown model" do
+    prompt = build(:completion_kit_prompt, llm_model: "totally-made-up-model")
+    expect(prompt.llm_model_provider).to be_nil
+  end
+end
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+Run: `bundle exec rspec spec/models/completion_kit/prompt_spec.rb -e "llm_model_provider"`
+Expected: NoMethodError.
+
+- [ ] **Step 3: Implement**
+
+In `app/models/completion_kit/prompt.rb`, add (after `display_name`):
+
+```ruby
+def llm_model_provider
+  ApiConfig.provider_for_model(llm_model)
+end
+```
+
+- [ ] **Step 4: Run tests — confirm green**
+
+Run: `bundle exec rspec spec/models/completion_kit/prompt_spec.rb -e "llm_model_provider"`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/completion_kit/prompt.rb spec/models/completion_kit/prompt_spec.rb
+git commit -m "add Prompt#llm_model_provider helper"
+```
+
+---
+
+### Task 8: Add CompletionKit::RateLimitError exception
+
+**Files:**
+- Create: `lib/completion_kit/errors.rb`
+- Modify: `lib/completion_kit.rb` (require the new file)
+- Test: `spec/lib/completion_kit/errors_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/lib/completion_kit/errors_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe CompletionKit::RateLimitError do
+  it "carries provider, status, and retry_after attributes" do
+    error = described_class.new("rate limited", provider: "openai", status: 429, retry_after: 30)
+    expect(error.message).to eq("rate limited")
+    expect(error.provider).to eq("openai")
+    expect(error.status).to eq(429)
+    expect(error.retry_after).to eq(30)
+  end
+
+  it "subclasses StandardError" do
+    expect(described_class.new).to be_a(StandardError)
+  end
+end
+
+RSpec.describe CompletionKit::ConfigurationError do
+  it "subclasses StandardError" do
+    expect(described_class.new).to be_a(StandardError)
+  end
+end
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+Run: `bundle exec rspec spec/lib/completion_kit/errors_spec.rb`
+Expected: NameError (`uninitialized constant CompletionKit::RateLimitError`).
+
+- [ ] **Step 3: Create the errors file**
+
+Create `lib/completion_kit/errors.rb`:
+
+```ruby
+module CompletionKit
+  class Error < StandardError; end
+
+  class ConfigurationError < Error; end
+
+  class RateLimitError < Error
+    attr_reader :provider, :status, :retry_after
+
+    def initialize(message = nil, provider: nil, status: nil, retry_after: nil)
+      super(message)
+      @provider = provider
+      @status = status
+      @retry_after = retry_after
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Require it from lib/completion_kit.rb**
+
+Open `lib/completion_kit.rb` and add `require "completion_kit/errors"` near the top with the other requires.
+
+- [ ] **Step 5: Run tests — confirm green**
+
+Run: `bundle exec rspec spec/lib/completion_kit/errors_spec.rb`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/completion_kit/errors.rb lib/completion_kit.rb spec/lib/completion_kit/errors_spec.rb
+git commit -m "add RateLimitError and ConfigurationError exception classes"
+```
+
+---
+
+### Task 9: Make LlmClient subclasses raise RateLimitError on 429
+
+**Files:**
+- Modify: each LlmClient subclass under `app/services/completion_kit/` — `openai_client.rb`, `anthropic_client.rb`, `ollama_client.rb`, `openrouter_client.rb`
+- Test: a spec for each subclass under `spec/services/completion_kit/` (create if missing)
+
+- [ ] **Step 1: List the subclasses**
+
+Run: `ls app/services/completion_kit/*_client.rb`
+
+You should see at least openai, anthropic, ollama, openrouter clients. For each, repeat steps 2–4.
+
+- [ ] **Step 2: Write the failing test (using OpenAiClient as the template)**
+
+Create or append `spec/services/completion_kit/openai_client_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe CompletionKit::OpenAiClient do
+  let(:client) { described_class.new(api_key: "sk-test") }
+
+  describe "#generate_completion" do
+    it "raises RateLimitError when the API returns 429" do
+      stub = Faraday::Adapter::Test::Stubs.new do |s|
+        s.post("/v1/chat/completions") { [429, { "Retry-After" => "30" }, '{"error":{"message":"rate limit"}}'] }
+      end
+      conn = Faraday.new { |b| b.adapter :test, stub }
+      allow(client).to receive(:build_connection).and_return(conn)
+
+      expect {
+        client.generate_completion("hi", model: "gpt-4o")
+      }.to raise_error(CompletionKit::RateLimitError) do |error|
+        expect(error.provider).to eq("openai")
+        expect(error.status).to eq(429)
+        expect(error.retry_after).to eq(30)
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Run the test — confirm it fails**
+
+Run: `bundle exec rspec spec/services/completion_kit/openai_client_spec.rb`
+Expected: failure (no rate-limit handling raises a different error or returns a value).
+
+- [ ] **Step 4: Update the client**
+
+In `app/services/completion_kit/openai_client.rb`, after the response is received and before parsing the body, add:
+
+```ruby
+if response.status == 429
+  raise CompletionKit::RateLimitError.new(
+    extract_message(response.body) || "Rate limit",
+    provider: "openai",
+    status: 429,
+    retry_after: response.headers["Retry-After"]&.to_i
+  )
+end
+```
+
+(`extract_message` is the existing helper used by the client; if it doesn't exist, just pass `response.body.to_s.truncate(500)`.)
+
+- [ ] **Step 5: Run the test — confirm green**
+
+Run: `bundle exec rspec spec/services/completion_kit/openai_client_spec.rb`
+
+- [ ] **Step 6: Repeat steps 2–5 for each other client**
+
+For `AnthropicClient`, `OllamaClient`, `OpenRouterClient`: write the same shape of test against the provider's endpoint, raise `RateLimitError.new(..., provider: "anthropic"|"ollama"|"openrouter", status: 429, ...)`. Anthropic uses the `anthropic-ratelimit-requests-reset` header; OpenAI uses `Retry-After`. If the provider doesn't expose a retry-after, pass `nil` and the job's fixed-step backoff covers it.
+
+- [ ] **Step 7: Run all client specs together**
+
+Run: `bundle exec rspec spec/services/completion_kit`
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/services/completion_kit spec/services/completion_kit
+git commit -m "raise RateLimitError on 429 across all LLM clients"
+```
+
+---
+
+### Task 10: Create GenerateRowJob with retries and concurrency
+
+**Files:**
+- Create: `app/jobs/completion_kit/generate_row_job.rb`
+- Test: `spec/jobs/completion_kit/generate_row_job_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/jobs/completion_kit/generate_row_job_spec.rb`:
+
+```ruby
+require "rails_helper"
+require "faraday"
+
+RSpec.describe CompletionKit::GenerateRowJob, type: :job do
+  let(:run) { create(:completion_kit_run) }
+  let(:response) { run.responses.create!(status: "pending", row_index: 0, response_text: nil) }
+
+  before do
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_progress)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_response_update)
+    allow(CompletionKit::RunCompletionCheckJob).to receive(:perform_later)
+  end
+
+  it "calls the LLM client and marks the response succeeded" do
+    fake_client = double("client", generate_completion: "the answer", configured?: true)
+    allow(CompletionKit::LlmClient).to receive(:for_model).and_return(fake_client)
+
+    described_class.perform_now(run.id, response.id)
+
+    response.reload
+    expect(response.status).to eq("succeeded")
+    expect(response.response_text).to eq("the answer")
+    expect(response.error_class).to be_nil
+  end
+
+  it "records terminal failure context after exhaustion of retries" do
+    allow_any_instance_of(described_class).to receive(:perform).and_raise(
+      CompletionKit::RateLimitError.new("over budget", provider: "openai", status: 429)
+    )
+
+    expect {
+      described_class.perform_now(run.id, response.id)
+    }.not_to raise_error
+
+    response.reload
+    expect(response.status).to eq("failed")
+    expect(response.error_provider).to eq("openai")
+    expect(response.error_status).to eq(429)
+    expect(response.error_class).to eq("CompletionKit::RateLimitError")
+    expect(response.error_message).to include("over budget")
+  end
+
+  it "enqueues a JudgeReviewJob per metric on success" do
+    metric = create(:completion_kit_metric)
+    CompletionKit::RunMetric.create!(run: run, metric: metric, position: 1)
+
+    fake_client = double("client", generate_completion: "ok", configured?: true)
+    allow(CompletionKit::LlmClient).to receive(:for_model).and_return(fake_client)
+    allow(run).to receive(:judge_configured?).and_return(true)
+    allow(CompletionKit::Run).to receive(:find).with(run.id).and_return(run)
+
+    expect(CompletionKit::JudgeReviewJob).to receive(:perform_later).with(response.id, metric.id)
+
+    described_class.perform_now(run.id, response.id)
+  end
+
+  it "enqueues RunCompletionCheckJob at the end" do
+    fake_client = double("client", generate_completion: "ok", configured?: true)
+    allow(CompletionKit::LlmClient).to receive(:for_model).and_return(fake_client)
+
+    expect(CompletionKit::RunCompletionCheckJob).to receive(:perform_later).with(run.id)
+
+    described_class.perform_now(run.id, response.id)
+  end
+end
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `bundle exec rspec spec/jobs/completion_kit/generate_row_job_spec.rb`
+Expected: NameError (job class doesn't exist).
+
+- [ ] **Step 3: Implement the job**
+
+Create `app/jobs/completion_kit/generate_row_job.rb`:
+
+```ruby
+module CompletionKit
+  class GenerateRowJob < ApplicationJob
+    queue_as :llm
+
+    retry_on Faraday::TimeoutError,
+             Faraday::ConnectionFailed,
+             wait: :polynomially_longer, attempts: 5
+
+    retry_on CompletionKit::RateLimitError,
+             wait: ->(executions) { 30 * executions }, attempts: 5
+
+    discard_on ActiveJob::DeserializationError
+    discard_on CompletionKit::ConfigurationError
+
+    rescue_from(StandardError) do |error|
+      record_terminal_failure!(error)
+      enqueue_completion_check
+    end
+
+    before_perform do |job|
+      response = Response.find_by(id: job.arguments.last)
+      next unless response
+      response.update_columns(status: "retrying", attempts: response.attempts + 1)
+      response.run.send(:broadcast_response_update, response) if response.run
+    end
+
+    def perform(run_id, response_id)
+      @run_id = run_id
+      @response_id = response_id
+
+      response = Response.find(response_id)
+      run = response.run
+      prompt = run.prompt
+
+      row = parsed_input(response)
+      rendered = CsvProcessor.apply_variables(prompt, row)
+      client = LlmClient.for_model(prompt.llm_model, ApiConfig.for_model(prompt.llm_model))
+
+      raise ConfigurationError, client.configuration_errors.join(", ") unless client.configured?
+
+      text = client.generate_completion(rendered, model: prompt.llm_model, temperature: run.temperature)
+
+      response.update!(
+        status: "succeeded",
+        response_text: text,
+        error_provider: nil, error_class: nil, error_status: nil, error_message: nil
+      )
+      run.send(:broadcast_response_update, response)
+
+      if run.judge_configured?
+        run.metrics.each do |metric|
+          JudgeReviewJob.perform_later(response.id, metric.id)
+        end
+      end
+
+      enqueue_completion_check
+    end
+
+    private
+
+    def parsed_input(response)
+      return {} if response.input_data.blank?
+      JSON.parse(response.input_data)
+    rescue JSON::ParserError
+      {}
+    end
+
+    def record_terminal_failure!(error)
+      response = Response.find_by(id: @response_id)
+      return unless response
+
+      response.update_columns(
+        status: "failed",
+        error_provider: provider_for(response),
+        error_class: error.class.name,
+        error_status: error.respond_to?(:status) ? error.status : nil,
+        error_message: error.message.to_s.truncate(2000)
+      )
+      response.run&.send(:broadcast_response_update, response)
+    end
+
+    def provider_for(response)
+      response.run&.prompt&.llm_model_provider
+    end
+
+    def enqueue_completion_check
+      RunCompletionCheckJob.perform_later(@run_id)
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the test — confirm green**
+
+Run: `bundle exec rspec spec/jobs/completion_kit/generate_row_job_spec.rb`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/jobs/completion_kit/generate_row_job.rb spec/jobs/completion_kit/generate_row_job_spec.rb
+git commit -m "add GenerateRowJob with retries and per-row failure capture"
+```
+
+---
+
+### Task 11: Create JudgeReviewJob
+
+**Files:**
+- Create: `app/jobs/completion_kit/judge_review_job.rb`
+- Test: `spec/jobs/completion_kit/judge_review_job_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/jobs/completion_kit/judge_review_job_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe CompletionKit::JudgeReviewJob, type: :job do
+  let(:run) { create(:completion_kit_run, judge_model: "gpt-4o") }
+  let(:metric) { create(:completion_kit_metric, name: "Quality") }
+  let(:response) { create(:completion_kit_response, run: run, response_text: "answer") }
+
+  before do
+    CompletionKit::RunMetric.create!(run: run, metric: metric, position: 1)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_response_update)
+    allow(CompletionKit::RunCompletionCheckJob).to receive(:perform_later)
+  end
+
+  it "evaluates and creates/updates a Review with succeeded status" do
+    fake_judge = double("judge")
+    allow(fake_judge).to receive(:evaluate).and_return(score: 4, feedback: "good")
+    allow(CompletionKit::JudgeService).to receive(:new).and_return(fake_judge)
+    allow(CompletionKit::ApiConfig).to receive(:for_model).and_return({})
+
+    described_class.perform_now(response.id, metric.id)
+
+    review = response.reviews.find_by(metric_id: metric.id)
+    expect(review.status).to eq("succeeded")
+    expect(review.ai_score).to eq(4)
+    expect(review.ai_feedback).to eq("good")
+  end
+
+  it "records failure context on terminal failure" do
+    allow_any_instance_of(described_class).to receive(:perform).and_raise(
+      CompletionKit::RateLimitError.new("limit", provider: "anthropic", status: 429)
+    )
+
+    described_class.perform_now(response.id, metric.id)
+
+    review = response.reviews.find_by(metric_id: metric.id)
+    expect(review.status).to eq("failed")
+    expect(review.error_provider).to eq("anthropic")
+    expect(review.error_status).to eq(429)
+  end
+
+  it "enqueues RunCompletionCheckJob" do
+    fake_judge = double("judge", evaluate: { score: 4, feedback: "ok" })
+    allow(CompletionKit::JudgeService).to receive(:new).and_return(fake_judge)
+    allow(CompletionKit::ApiConfig).to receive(:for_model).and_return({})
+
+    expect(CompletionKit::RunCompletionCheckJob).to receive(:perform_later).with(run.id)
+
+    described_class.perform_now(response.id, metric.id)
+  end
+end
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `bundle exec rspec spec/jobs/completion_kit/judge_review_job_spec.rb`
+Expected: NameError.
+
+- [ ] **Step 3: Implement the job**
+
+Create `app/jobs/completion_kit/judge_review_job.rb`:
+
+```ruby
+module CompletionKit
+  class JudgeReviewJob < ApplicationJob
+    queue_as :llm
+
+    retry_on Faraday::TimeoutError,
+             Faraday::ConnectionFailed,
+             wait: :polynomially_longer, attempts: 5
+
+    retry_on CompletionKit::RateLimitError,
+             wait: ->(executions) { 30 * executions }, attempts: 5
+
+    discard_on ActiveJob::DeserializationError
+    discard_on CompletionKit::ConfigurationError
+
+    rescue_from(StandardError) do |error|
+      record_terminal_failure!(error)
+      enqueue_completion_check
+    end
+
+    before_perform do |job|
+      response_id, metric_id = job.arguments
+      review = find_or_init_review(response_id, metric_id)
+      review.attempts = (review.attempts || 0) + 1
+      review.status = "retrying"
+      review.save!(validate: false)
+      review.response.run.send(:broadcast_response_update, review.response) if review.response&.run
+    end
+
+    def perform(response_id, metric_id)
+      @response_id = response_id
+      @metric_id = metric_id
+
+      response = Response.find(response_id)
+      metric = Metric.find(metric_id)
+      run = response.run
+
+      judge = JudgeService.new(ApiConfig.for_model(run.judge_model).merge(judge_model: run.judge_model))
+      evaluation = judge.evaluate(
+        response.response_text,
+        response.expected_output,
+        run.prompt.template,
+        criteria: metric.instruction.to_s,
+        rubric_text: metric.display_rubric_text,
+        input_data: response.input_data
+      )
+
+      review = response.reviews.find_or_initialize_by(metric_id: metric.id)
+      review.assign_attributes(
+        metric_name: metric.name,
+        instruction: metric.instruction.to_s,
+        status: "succeeded",
+        ai_score: evaluation[:score],
+        ai_feedback: evaluation[:feedback],
+        error_provider: nil, error_class: nil, error_status: nil, error_message: nil
+      )
+      review.save!
+
+      run.send(:broadcast_response_update, response)
+      enqueue_completion_check
+    end
+
+    private
+
+    def find_or_init_review(response_id, metric_id)
+      Response.find(response_id).reviews.find_or_initialize_by(metric_id: metric_id).tap do |r|
+        r.metric_name ||= Metric.find(metric_id).name
+      end
+    end
+
+    def record_terminal_failure!(error)
+      response = Response.find_by(id: @response_id)
+      return unless response
+      review = response.reviews.find_or_initialize_by(metric_id: @metric_id)
+      review.assign_attributes(
+        metric_name: review.metric_name || Metric.find_by(id: @metric_id)&.name || "(deleted metric)",
+        status: "failed",
+        error_provider: response.run&.judge_model && ApiConfig.provider_for_model(response.run.judge_model),
+        error_class: error.class.name,
+        error_status: error.respond_to?(:status) ? error.status : nil,
+        error_message: error.message.to_s.truncate(2000)
+      )
+      review.save!(validate: false)
+      response.run&.send(:broadcast_response_update, response)
+    end
+
+    def enqueue_completion_check
+      response = Response.find_by(id: @response_id)
+      RunCompletionCheckJob.perform_later(response.run_id) if response
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run the test — confirm green**
+
+Run: `bundle exec rspec spec/jobs/completion_kit/judge_review_job_spec.rb`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/jobs/completion_kit/judge_review_job.rb spec/jobs/completion_kit/judge_review_job_spec.rb
+git commit -m "add JudgeReviewJob with per-review retries and failure capture"
+```
+
+---
+
+### Task 12: Create RunCompletionCheckJob
+
+**Files:**
+- Create: `app/jobs/completion_kit/run_completion_check_job.rb`
+- Test: `spec/jobs/completion_kit/run_completion_check_job_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `spec/jobs/completion_kit/run_completion_check_job_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe CompletionKit::RunCompletionCheckJob, type: :job do
+  let(:run) { create(:completion_kit_run, status: "running") }
+
+  before do
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_ui)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_progress)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_status_header)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_actions)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_sort_toolbar)
+  end
+
+  it "marks run completed when no responses are outstanding" do
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "ok")
+
+    described_class.perform_now(run.id)
+
+    expect(run.reload.status).to eq("completed")
+  end
+
+  it "leaves run as running when at least one response is non-terminal" do
+    create(:completion_kit_response, run: run, status: "pending", response_text: nil)
+
+    described_class.perform_now(run.id)
+
+    expect(run.reload.status).to eq("running")
+  end
+
+  it "leaves run as running when at least one expected review is non-terminal" do
+    metric = create(:completion_kit_metric)
+    CompletionKit::RunMetric.create!(run: run, metric: metric, position: 1)
+    response = create(:completion_kit_response, run: run, status: "succeeded", response_text: "ok")
+    response.reviews.create!(metric: metric, metric_name: metric.name, status: "pending")
+
+    described_class.perform_now(run.id)
+
+    expect(run.reload.status).to eq("running")
+  end
+
+  it "is a no-op when run is already completed" do
+    run.update!(status: "completed")
+    described_class.perform_now(run.id)
+    expect(run.reload.status).to eq("completed")
+  end
+
+  it "handles missing run gracefully" do
+    expect { described_class.perform_now(999_999) }.not_to raise_error
+  end
+end
+```
+
+- [ ] **Step 2: Run — confirm it fails**
+
+Run: `bundle exec rspec spec/jobs/completion_kit/run_completion_check_job_spec.rb`
+Expected: NameError.
+
+- [ ] **Step 3: Implement the job**
+
+Create `app/jobs/completion_kit/run_completion_check_job.rb`:
+
+```ruby
+module CompletionKit
+  class RunCompletionCheckJob < ApplicationJob
+    queue_as :default
+
+    def perform(run_id)
+      run = Run.find_by(id: run_id)
+      return unless run
+      return unless run.status == "running"
+      return unless run.outstanding_work_zero?
+
+      run.mark_completed!
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run — confirm green**
+
+Run: `bundle exec rspec spec/jobs/completion_kit/run_completion_check_job_spec.rb`
+
+(The `outstanding_work_zero?` and `mark_completed!` methods on Run will be added in Task 13. The test will fail at this stage if those don't exist — proceed to Task 13 first if needed, then re-run this test, then commit Tasks 12 and 13 together.)
+
+- [ ] **Step 5: Commit (after Task 13 lands)**
+
+```bash
+git add app/jobs/completion_kit/run_completion_check_job.rb spec/jobs/completion_kit/run_completion_check_job_spec.rb
+git commit -m "add RunCompletionCheckJob"
+```
+
+---
+
+### Task 13: Add Run#start!, #outstanding_work_zero?, #mark_completed!, #progress_snapshot
+
+**Files:**
+- Modify: `app/models/completion_kit/run.rb`
+- Modify: `spec/models/completion_kit/run_spec.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `spec/models/completion_kit/run_spec.rb`, append:
+
+```ruby
+describe "#start!" do
+  let(:dataset) do
+    create(:completion_kit_dataset, csv_data: "content,audience\nrelease notes,devs\nfeature recap,pms\n")
+  end
+  let(:prompt) { create(:completion_kit_prompt, llm_model: "gpt-4o") }
+  let(:run) { create(:completion_kit_run, prompt: prompt, dataset: dataset) }
+
+  before do
+    allow(CompletionKit::ApiConfig).to receive(:valid_for_model?).and_return(true)
+    allow(CompletionKit::GenerateRowJob).to receive(:perform_later)
+  end
+
+  it "creates one pending Response per dataset row with row_index set" do
+    run.start!
+
+    expect(run.responses.count).to eq(2)
+    expect(run.responses.pluck(:status).uniq).to eq(["pending"])
+    expect(run.responses.order(:row_index).pluck(:row_index)).to eq([0, 1])
+  end
+
+  it "enqueues a GenerateRowJob per row" do
+    expect(CompletionKit::GenerateRowJob).to receive(:perform_later).twice
+    run.start!
+  end
+
+  it "transitions to running and resets progress totals" do
+    run.start!
+    expect(run.reload.status).to eq("running")
+    expect(run.progress_total).to eq(2)
+    expect(run.progress_current).to eq(0)
+  end
+
+  it "fails with a configuration error when API isn't configured" do
+    allow(CompletionKit::ApiConfig).to receive(:valid_for_model?).and_return(false)
+    allow_any_instance_of(CompletionKit::LlmClient).to receive(:configuration_errors).and_return(["missing api key"])
+
+    expect(run.start!).to be(false)
+    expect(run.reload.status).to eq("failed")
+    expect(run.failure_summary).to be_present
+  end
+end
+
+describe "#outstanding_work_zero?" do
+  let(:run) { create(:completion_kit_run) }
+
+  it "returns true when all responses and reviews are terminal" do
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "ok")
+    expect(run.outstanding_work_zero?).to be true
+  end
+
+  it "returns false when any response is non-terminal" do
+    create(:completion_kit_response, run: run, status: "pending", response_text: nil)
+    expect(run.outstanding_work_zero?).to be false
+  end
+
+  it "returns false when any review is non-terminal" do
+    metric = create(:completion_kit_metric)
+    CompletionKit::RunMetric.create!(run: run, metric: metric, position: 1)
+    response = create(:completion_kit_response, run: run, status: "succeeded", response_text: "ok")
+    response.reviews.create!(metric: metric, metric_name: metric.name, status: "pending")
+    expect(run.outstanding_work_zero?).to be false
+  end
+end
+
+describe "#progress_snapshot" do
+  let(:run) { create(:completion_kit_run) }
+
+  it "returns counts for both gen and judge phases" do
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "a")
+    create(:completion_kit_response, run: run, status: "failed", response_text: nil)
+    create(:completion_kit_response, run: run, status: "pending", response_text: nil)
+    run.update!(progress_total: 3)
+
+    snap = run.progress_snapshot
+    expect(snap[:generated_done]).to eq(2)
+    expect(snap[:generated_total]).to eq(3)
+    expect(snap[:generated_failed]).to eq(1)
+    expect(snap[:judged_done]).to eq(0)
+    expect(snap[:judged_total]).to eq(0)
+  end
+end
+```
+
+- [ ] **Step 2: Run — confirm they fail**
+
+Run: `bundle exec rspec spec/models/completion_kit/run_spec.rb`
+Expected: failures.
+
+- [ ] **Step 3: Implement the new methods on Run**
+
+In `app/models/completion_kit/run.rb`, add (and remove the old `generate_responses!` / `judge_responses!` bodies — or repoint them; see Step 4):
+
+```ruby
+def start!
+  rows = if dataset
+           CsvProcessor.process_self(self)
+         else
+           [{}]
+         end
+
+  if rows.empty?
+    return fail_with_summary!("Dataset has no rows")
+  end
+
+  client = LlmClient.for_model(prompt.llm_model, ApiConfig.for_model(prompt.llm_model))
+  unless client.configured?
+    return fail_with_summary!("LLM API not configured: #{client.configuration_errors.join(', ')}")
+  end
+
+  transaction do
+    responses.destroy_all
+    update!(
+      status: "running",
+      progress_current: 0,
+      progress_total: rows.length,
+      failure_summary: nil,
+      error_message: nil
+    )
+    rows.each_with_index do |row, index|
+      input = row.empty? ? nil : row.to_json
+      response = responses.create!(
+        status: "pending",
+        row_index: index,
+        input_data: input,
+        expected_output: row.is_a?(Hash) ? row["expected_output"] : nil
+      )
+      GenerateRowJob.perform_later(id, response.id)
+    end
+  end
+
+  broadcast_ui
+  broadcast_clear_responses
+  true
+end
+
+def outstanding_work_zero?
+  return false if responses.where.not(status: Response::TERMINAL_STATUSES).exists?
+
+  metric_ids = metrics.pluck(:id)
+  return true if metric_ids.empty?
+
+  succeeded_response_ids = responses.where(status: "succeeded").pluck(:id)
+  expected_reviews = succeeded_response_ids.size * metric_ids.size
+
+  return true if expected_reviews.zero?
+
+  terminal_review_count = Review.where(
+    response_id: succeeded_response_ids,
+    metric_id: metric_ids,
+    status: Review::TERMINAL_STATUSES
+  ).count
+
+  terminal_review_count >= expected_reviews
+end
+
+def mark_completed!
+  update!(status: "completed")
+  broadcast_ui
+end
+
+def progress_snapshot
+  generated_done = responses.where(status: "succeeded").count
+  generated_failed = responses.where(status: "failed").count
+  generated_total = progress_total
+
+  metric_count = metrics.count
+  succeeded_count = generated_done
+  judged_total = succeeded_count * metric_count
+  judged_done = Review.joins(:response)
+    .where(completion_kit_responses: { run_id: id }, status: "succeeded").count
+  judged_failed = Review.joins(:response)
+    .where(completion_kit_responses: { run_id: id }, status: "failed").count
+
+  {
+    generated_done: generated_done,
+    generated_total: generated_total,
+    generated_failed: generated_failed,
+    judged_done: judged_done,
+    judged_total: judged_total,
+    judged_failed: judged_failed
+  }
+end
+
+private
+
+def fail_with_summary!(message)
+  errors.add(:base, message)
+  if persisted?
+    update_columns(status: "failed", failure_summary: message, error_message: message)
+    broadcast_ui
+  end
+  false
+end
+```
+
+- [ ] **Step 4: Repoint or remove the old generate_responses! and judge_responses!**
+
+Replace `Run#generate_responses!` with a deprecation stub that just calls `start!`:
+
+```ruby
+def generate_responses!
+  start!
+end
+```
+
+Remove `Run#judge_responses!` entirely (it is no longer reachable; the controller's `judge` action is also removed in Task 14).
+
+- [ ] **Step 5: Run all run specs — confirm green**
+
+Run: `bundle exec rspec spec/models/completion_kit/run_spec.rb`
+
+- [ ] **Step 6: Re-run the RunCompletionCheckJob spec from Task 12**
+
+Run: `bundle exec rspec spec/jobs/completion_kit/run_completion_check_job_spec.rb`
+Expected: green now that `outstanding_work_zero?` and `mark_completed!` exist.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/models/completion_kit/run.rb spec/models/completion_kit/run_spec.rb
+git commit -m "add Run#start, outstanding_work_zero?, mark_completed!, progress_snapshot"
+```
+
+---
+
+### Task 14: Switch RunsController#generate to call run.start!
+
+**Files:**
+- Modify: `app/controllers/completion_kit/runs_controller.rb`
+- Modify: `app/controllers/completion_kit/api/v1/runs_controller.rb`
+- Test: `spec/requests/completion_kit/api/v1/runs_controller_spec.rb` if it exists, otherwise the controller spec under `spec/controllers/`
+
+- [ ] **Step 1: Find the existing controller specs**
+
+Run: `find spec -name "runs_controller_spec*"`
+
+- [ ] **Step 2: Update the web controller**
+
+In `app/controllers/completion_kit/runs_controller.rb`, replace the `generate` action:
+
+```ruby
+def generate
+  if @run.start!
+    redirect_to run_path(@run)
+  else
+    redirect_to run_path(@run), alert: @run.failure_summary || @run.errors.full_messages.to_sentence
+  end
+end
+```
+
+Remove the `judge` action and the route for it (Task 17 covers the route change). Judging is now triggered as part of `start!` via the per-row jobs.
+
+- [ ] **Step 3: Update the API controller**
+
+In `app/controllers/completion_kit/api/v1/runs_controller.rb`, replace the `generate` action:
+
+```ruby
+def generate
+  if @run.start!
+    render json: @run.reload, status: :accepted
+  else
+    render json: { errors: [@run.failure_summary || @run.errors.full_messages.to_sentence] }, status: :unprocessable_entity
+  end
+end
+```
+
+Remove the API `judge` action.
+
+- [ ] **Step 4: Run any existing controller/request specs**
+
+Run: `bundle exec rspec spec/controllers spec/requests 2>/dev/null || true`
+
+Update assertions that expected the controller to call `GenerateJob.perform_later(@run.id)` to instead expect `run.start!` (or stub it). Remove tests for the deleted `judge` action.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/controllers/completion_kit
+git commit -m "controllers: replace generate/judge with run.start"
+```
+
+---
+
+### Task 15: Delete or repoint old GenerateJob and JudgeJob
+
+**Files:**
+- Delete: `app/jobs/completion_kit/generate_job.rb`
+- Delete: `app/jobs/completion_kit/judge_job.rb`
+- Delete: `spec/jobs/completion_kit/generate_job_spec.rb`
+- Delete: `spec/jobs/completion_kit/judge_job_spec.rb`
+
+- [ ] **Step 1: Confirm nothing references them**
+
+Run: `grep -rn "GenerateJob\|JudgeJob" app spec lib config 2>/dev/null | grep -v "Row\|Review\|spec/jobs/.*_job_spec"`
+
+If anything is still referenced, fix the references first.
+
+- [ ] **Step 2: Delete**
+
+```bash
+git rm app/jobs/completion_kit/generate_job.rb app/jobs/completion_kit/judge_job.rb spec/jobs/completion_kit/generate_job_spec.rb spec/jobs/completion_kit/judge_job_spec.rb
+```
+
+- [ ] **Step 3: Run the full suite to make sure nothing breaks**
+
+Run: `bundle exec rspec`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "remove old monolithic GenerateJob and JudgeJob"
+```
+
+---
+
+### Task 16: Add Solid Queue concurrency limits to the new jobs
+
+**Files:**
+- Modify: `app/jobs/completion_kit/generate_row_job.rb`
+- Modify: `app/jobs/completion_kit/judge_review_job.rb`
+- Modify: `app/jobs/completion_kit/run_completion_check_job.rb`
+
+(Solid Queue's `limits_concurrency` is a class-level DSL exposed by the `solid_queue` gem; it is a no-op in tests because Active Job's TestAdapter ignores it.)
+
+- [ ] **Step 1: Add per-provider + per-run limits to GenerateRowJob**
+
+In `app/jobs/completion_kit/generate_row_job.rb`, after `queue_as :llm`:
+
+```ruby
+limits_concurrency to: ENV.fetch("COMPLETION_KIT_LLM_CONCURRENCY", 10).to_i,
+                   key: ->(run_id, _) { "llm:gen:#{Run.find_by(id: run_id)&.prompt&.llm_model_provider || 'unknown'}" },
+                   duration: 10.minutes
+
+limits_concurrency to: ENV.fetch("COMPLETION_KIT_PER_RUN_CONCURRENCY", 5).to_i,
+                   key: ->(run_id, _) { "run:#{run_id}" },
+                   duration: 10.minutes
+```
+
+- [ ] **Step 2: Add per-judge-provider + per-run limits to JudgeReviewJob**
+
+In `app/jobs/completion_kit/judge_review_job.rb`, after `queue_as :llm`:
+
+```ruby
+limits_concurrency to: ENV.fetch("COMPLETION_KIT_LLM_CONCURRENCY", 10).to_i,
+                   key: ->(response_id, _) {
+                     run = Response.find_by(id: response_id)&.run
+                     "llm:judge:#{run&.judge_model && ApiConfig.provider_for_model(run.judge_model) || 'unknown'}"
+                   },
+                   duration: 10.minutes
+
+limits_concurrency to: ENV.fetch("COMPLETION_KIT_PER_RUN_CONCURRENCY", 5).to_i,
+                   key: ->(response_id, _) { "run:#{Response.find_by(id: response_id)&.run_id}" },
+                   duration: 10.minutes
+```
+
+- [ ] **Step 3: Serialize completion checks per run**
+
+In `app/jobs/completion_kit/run_completion_check_job.rb`, after `queue_as :default`:
+
+```ruby
+limits_concurrency to: 1,
+                   key: ->(run_id) { "run:#{run_id}:completion" },
+                   duration: 5.minutes
+```
+
+- [ ] **Step 4: Run the full suite to confirm DSL doesn't blow up at load time**
+
+Run: `bundle exec rspec spec/jobs`
+
+(In specs the DSL is loaded but unused; the Active Job adapter is `:test`. If you see `NoMethodError: undefined method 'limits_concurrency'`, the engine spec dummy app is missing solid_queue — see Task 18.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/jobs/completion_kit
+git commit -m "add concurrency limits to row and review jobs"
+```
+
+---
+
+### Task 17: Remove the judge route, keep generate
+
+**Files:**
+- Modify: `config/routes.rb`
+- Modify: `app/views/completion_kit/runs/_actions.html.erb` if it has a "Judge" button
+
+- [ ] **Step 1: Remove the judge route in both web and API**
+
+In `config/routes.rb`, remove `post :judge` from both the engine routes and `api/v1/runs`.
+
+- [ ] **Step 2: Remove any "Judge" link in views**
+
+Run: `grep -rn "judge_run_path\|:judge" app/views` and remove the calls, since judging now happens automatically as part of generate.
+
+- [ ] **Step 3: Run full spec — should be green**
+
+Run: `bundle exec rspec`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/routes.rb app/views
+git commit -m "drop standalone judge action; judging now triggered per-row"
+```
+
+---
+
+### Task 18: Make the engine's spec environment Solid-Queue-aware
+
+**Files:**
+- Modify: `Gemfile` (engine root) — add solid_queue as a development dependency for the dummy app
+- Modify: `completion_kit.gemspec`
+
+- [ ] **Step 1: Add solid_queue to the engine's dev dependencies**
+
+In `completion_kit.gemspec`, add:
+
+```ruby
+spec.add_development_dependency "solid_queue", "~> 1.0"
+```
+
+- [ ] **Step 2: Bundle**
+
+Run: `bundle install`
+
+- [ ] **Step 3: Confirm Gemfile.lock has solid_queue**
+
+Run: `grep solid_queue Gemfile.lock`
+
+- [ ] **Step 4: Re-run the full spec**
+
+Run: `bundle exec rspec`
+Expected: green. The `limits_concurrency` DSL now resolves at load time even though the test adapter ignores it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add completion_kit.gemspec Gemfile.lock
+git commit -m "add solid_queue as engine dev dependency for spec load"
+```
+
+---
+
+### Task 19: Switch the standalone production and development queue adapters
+
+**Files:**
+- Modify: `standalone/config/environments/production.rb`
+- Modify: `standalone/config/environments/development.rb`
+- Modify: `standalone/Procfile.dev` (create if missing)
+
+- [ ] **Step 1: Switch production**
+
+In `standalone/config/environments/production.rb`:
+
+Replace `config.active_job.queue_adapter = :async` with `config.active_job.queue_adapter = :solid_queue`.
+
+- [ ] **Step 2: Switch development**
+
+In `standalone/config/environments/development.rb`:
+
+Replace `config.active_job.queue_adapter = :async` with `config.active_job.queue_adapter = :solid_queue`.
+
+- [ ] **Step 3: Update the dev Procfile**
+
+If `standalone/Procfile.dev` does not exist, check `standalone/bin/dev` for the existing process list. Either way, ensure there is a `worker` line:
+
+```
+web: bin/rails s
+worker: bin/jobs
+```
+
+- [ ] **Step 4: Boot locally and verify**
+
+Run: `cd standalone && foreman start -f Procfile.dev` (or `bin/dev` if that's the pattern).
+
+Trigger a test run from the UI and confirm in `standalone/log/development.log` that `GenerateRowJob` is enqueued and processed by the worker.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add standalone/config/environments standalone/Procfile.dev
+git commit -m "switch standalone queue adapter to solid_queue"
+```
+
+---
+
+### Task 20: Add the cutover rake task and boot warning
+
+**Files:**
+- Create: `lib/tasks/completion_kit_runs.rake`
+- Create: `config/initializers/completion_kit_concurrency_check.rb` (in standalone)
+
+- [ ] **Step 1: Add the rake task**
+
+Create `lib/tasks/completion_kit_runs.rake`:
+
+```ruby
+namespace :completion_kit do
+  desc "Mark in-flight runs as failed (for use after the queue adapter cutover)"
+  task mark_interrupted_runs_failed: :environment do
+    scope = CompletionKit::Run.where(status: "running")
+    count = scope.count
+    scope.update_all(
+      status: "failed",
+      failure_summary: "Interrupted by deploy",
+      updated_at: Time.current
+    )
+    puts "Marked #{count} runs as failed."
+  end
+end
+```
+
+- [ ] **Step 2: Add the boot-time warning**
+
+Create `standalone/config/initializers/completion_kit_concurrency_check.rb`:
+
+```ruby
+Rails.application.config.after_initialize do
+  threads = ENV.fetch("SOLID_QUEUE_THREADS", 10).to_i
+  llm_cap = ENV.fetch("COMPLETION_KIT_LLM_CONCURRENCY", 10).to_i
+
+  if threads < llm_cap
+    Rails.logger.warn(
+      "[CompletionKit] SOLID_QUEUE_THREADS=#{threads} is less than " \
+      "COMPLETION_KIT_LLM_CONCURRENCY=#{llm_cap}; threads will be the " \
+      "actual bottleneck and the per-provider cap will never be reached."
+    )
+  end
+end
+```
+
+- [ ] **Step 3: Verify the task is loadable**
+
+Run: `cd standalone && bin/rails completion_kit:mark_interrupted_runs_failed`
+Expected: prints "Marked 0 runs as failed."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/tasks/completion_kit_runs.rake standalone/config/initializers/completion_kit_concurrency_check.rb
+git commit -m "add cutover rake task and concurrency boot warning"
+```
+
+> **PR 2 ends here.** Before merging:
+> 1. Confirm Render Worker service has been created with the start command `cd standalone && bin/jobs` and the env vars from the spec (§Deployment in the design doc).
+> 2. Add a one-time post-deploy hook (or run manually after deploy) for `cd standalone && bin/rails completion_kit:mark_interrupted_runs_failed` to clean up any runs that were in flight under `:async` at cutover.
+> 3. After deploy, kick off a small generation run from the UI; confirm progress is visible and a worker process is doing the work (Render → Worker service logs).
+
+---
+
+# Phase 3 (PR 3): UI + API
+
+> Goal of this PR: rewrite the status header and response row to reflect the new four-counter progress model, add a Retry-Failed-Rows action, extend the JSON API.
+
+---
+
+### Task 21: Rewrite the status header partial to use progress_snapshot
+
+**Files:**
+- Modify: `app/views/completion_kit/runs/_status_header.html.erb`
+- Test: existing run-page request spec (or create one)
+
+- [ ] **Step 1: Replace the partial**
+
+Open `app/views/completion_kit/runs/_status_header.html.erb` and replace its contents with:
+
+```erb
+<% snap = run.progress_snapshot %>
+<div id="run_status_header" class="run-status-header">
+  <% if run.status == "pending" %>
+    <span class="status-badge status-pending">Pending</span>
+  <% elsif run.status == "running" %>
+    <span class="status-badge status-running">● Running</span>
+  <% elsif run.status == "completed" %>
+    <span class="status-badge status-completed">✓ Completed</span>
+    <% if run.avg_score %>
+      <span class="run-avg-score">avg score <%= run.avg_score %></span>
+    <% end %>
+  <% elsif run.status == "failed" %>
+    <span class="status-badge status-failed">✕ Failed</span>
+    <% if run.failure_summary.present? %>
+      <span class="failure-summary"><%= run.failure_summary %></span>
+    <% end %>
+  <% end %>
+
+  <% if run.status.in?(%w[running completed]) %>
+    <div class="run-progress-block">
+      <div class="run-progress-line">
+        Generated <%= snap[:generated_done] %>/<%= snap[:generated_total] %>
+        <% if snap[:generated_failed] > 0 %>
+          <span class="failure-count">(<%= snap[:generated_failed] %> failed)</span>
+        <% end %>
+      </div>
+      <% if snap[:judged_total] > 0 %>
+        <div class="run-progress-line">
+          Judged <%= snap[:judged_done] %>/<%= snap[:judged_total] %>
+          <% if snap[:judged_failed] > 0 %>
+            <span class="failure-count">(<%= snap[:judged_failed] %> failed)</span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <% failed_count = snap[:generated_failed] + snap[:judged_failed] %>
+    <% if failed_count > 0 %>
+      <%= button_to "Retry #{failed_count} failed rows", retry_failures_run_path(run),
+            method: :post, class: "btn btn-secondary btn-sm retry-failures-btn" %>
+    <% end %>
+  <% end %>
+</div>
+```
+
+- [ ] **Step 2: Confirm the run show page still renders without error**
+
+Run: `bundle exec rspec spec/requests` if there are request specs; otherwise smoke-test in the dev server.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/views/completion_kit/runs/_status_header.html.erb
+git commit -m "rewrite status header for split gen/judge counters"
+```
+
+---
+
+### Task 22: Rewrite the response row partial
+
+**Files:**
+- Modify: `app/views/completion_kit/runs/_response_row.html.erb`
+
+- [ ] **Step 1: Read the current partial**
+
+Run: `cat app/views/completion_kit/runs/_response_row.html.erb`
+
+- [ ] **Step 2: Replace it**
+
+Open the file and replace the contents with a structure that branches on `response.status`:
+
+```erb
+<div id="response_<%= response.id %>" class="response-row response-status-<%= response.status %>">
+  <div class="response-header">
+    <span class="response-index">#<%= (response.row_index || 0) + 1 %></span>
+    <% case response.status
+       when "pending" %>
+      <span class="response-state state-pending">queued</span>
+    <% when "retrying" %>
+      <span class="response-state state-retrying">retrying… attempt <%= response.attempts %>/5</span>
+    <% when "succeeded" %>
+      <span class="response-state state-succeeded">✓</span>
+    <% when "failed" %>
+      <% err = response.error_payload %>
+      <span class="response-state state-failed" title="<%= err && err[:message] %>">
+        Failed: <%= err && err[:provider]&.titleize %>
+        <%= err && err[:status] %>
+        — <%= err && err[:message]&.truncate(80) %>
+      </span>
+      <%= button_to "Retry", retry_failures_run_path(run, only: response.id),
+            method: :post, class: "btn btn-link btn-xs retry-row-btn" %>
+    <% end %>
+  </div>
+
+  <% if response.status == "succeeded" %>
+    <div class="response-text"><%= simple_format(response.response_text) %></div>
+    <% if response.expected_output.present? %>
+      <div class="expected-output">Expected: <%= response.expected_output %></div>
+    <% end %>
+    <div class="reviews">
+      <% response.reviews.each do |review| %>
+        <div id="review_<%= review.id %>" class="review review-status-<%= review.status %>">
+          <span class="review-metric"><%= review.metric_name %></span>
+          <% case review.status
+             when "succeeded" %>
+            <span class="review-score"><%= review.ai_score %></span>
+            <% if review.ai_feedback.present? %>
+              <details><summary>feedback</summary><%= simple_format(review.ai_feedback) %></details>
+            <% end %>
+          <% when "retrying" %>
+            <span class="review-state">retrying… <%= review.attempts %>/5</span>
+          <% when "failed" %>
+            <% rerr = review.error_payload %>
+            <span class="review-state state-failed" title="<%= rerr && rerr[:message] %>">
+              Failed: <%= rerr && rerr[:provider]&.titleize %>
+              <%= rerr && rerr[:status] %>
+            </span>
+          <% else %>
+            <span class="review-state">queued</span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+```
+
+- [ ] **Step 3: Smoke-test in the dev server**
+
+Boot the dev stack and trigger a test run with a flaky stub (or a real provider with an intentionally bad key) to confirm the failed/retrying/succeeded states render.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/views/completion_kit/runs/_response_row.html.erb
+git commit -m "rewrite response row partial for new states and provider error"
+```
+
+---
+
+### Task 23: Add retry_failures controller action and route
+
+**Files:**
+- Modify: `config/routes.rb`
+- Modify: `app/controllers/completion_kit/runs_controller.rb`
+- Modify: `app/controllers/completion_kit/api/v1/runs_controller.rb`
+- Test: `spec/requests/completion_kit/runs_retry_failures_spec.rb` (create)
+
+- [ ] **Step 1: Add the routes**
+
+In `config/routes.rb`, inside the engine `resources :runs do member do … end` block, add `post :retry_failures`. Inside the `api/v1` `resources :runs do member do … end`, add the same.
+
+- [ ] **Step 2: Write the failing request spec**
+
+Create `spec/requests/completion_kit/runs_retry_failures_spec.rb`:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe "POST /completion_kit/runs/:id/retry_failures", type: :request do
+  let(:run) { create(:completion_kit_run, status: "completed") }
+
+  before do
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_ui)
+    allow(CompletionKit::GenerateRowJob).to receive(:perform_later)
+  end
+
+  it "resets failed responses to pending and re-enqueues their jobs" do
+    failed = create(:completion_kit_response, :failed, run: run, row_index: 0)
+    succeeded = create(:completion_kit_response, run: run, status: "succeeded", row_index: 1, response_text: "ok")
+
+    post "/completion_kit/runs/#{run.id}/retry_failures"
+
+    failed.reload
+    succeeded.reload
+
+    expect(failed.status).to eq("pending")
+    expect(failed.error_class).to be_nil
+    expect(failed.attempts).to eq(0)
+    expect(succeeded.status).to eq("succeeded")
+    expect(run.reload.status).to eq("running")
+    expect(CompletionKit::GenerateRowJob).to have_received(:perform_later).with(run.id, failed.id)
+    expect(CompletionKit::GenerateRowJob).not_to have_received(:perform_later).with(run.id, succeeded.id)
+  end
+
+  it "scopes to a single response when only param is supplied" do
+    failed_a = create(:completion_kit_response, :failed, run: run, row_index: 0)
+    failed_b = create(:completion_kit_response, :failed, run: run, row_index: 1)
+
+    post "/completion_kit/runs/#{run.id}/retry_failures", params: { only: failed_a.id }
+
+    expect(failed_a.reload.status).to eq("pending")
+    expect(failed_b.reload.status).to eq("failed")
+    expect(CompletionKit::GenerateRowJob).to have_received(:perform_later).with(run.id, failed_a.id)
+    expect(CompletionKit::GenerateRowJob).not_to have_received(:perform_later).with(run.id, failed_b.id)
+  end
+end
+```
+
+- [ ] **Step 3: Run — confirm failure**
+
+Run: `bundle exec rspec spec/requests/completion_kit/runs_retry_failures_spec.rb`
+Expected: routing error.
+
+- [ ] **Step 4: Implement the action**
+
+In `app/controllers/completion_kit/runs_controller.rb`, add to `before_action :set_run` and define:
+
+```ruby
+def retry_failures
+  scope = @run.responses.where(status: "failed")
+  scope = scope.where(id: params[:only]) if params[:only].present?
+
+  ActiveRecord::Base.transaction do
+    failed_response_ids = scope.pluck(:id)
+    Review.where(response_id: failed_response_ids, status: "failed").update_all(
+      status: "pending",
+      attempts: 0,
+      error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+      ai_score: nil, ai_feedback: nil
+    )
+    scope.update_all(
+      status: "pending",
+      attempts: 0,
+      error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+      response_text: nil
+    )
+    @run.update!(status: "running")
+    failed_response_ids.each { |rid| GenerateRowJob.perform_later(@run.id, rid) }
+  end
+
+  @run.send(:broadcast_ui)
+  redirect_to run_path(@run)
+end
+```
+
+Add `:retry_failures` to the `before_action :set_run` only-list.
+
+- [ ] **Step 5: Implement the API equivalent**
+
+In `app/controllers/completion_kit/api/v1/runs_controller.rb`:
+
+```ruby
+def retry_failures
+  scope = @run.responses.where(status: "failed")
+  scope = scope.where(id: params[:only]) if params[:only].present?
+
+  ActiveRecord::Base.transaction do
+    failed_response_ids = scope.pluck(:id)
+    CompletionKit::Review.where(response_id: failed_response_ids, status: "failed").update_all(
+      status: "pending", attempts: 0,
+      error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+      ai_score: nil, ai_feedback: nil
+    )
+    scope.update_all(
+      status: "pending", attempts: 0,
+      error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+      response_text: nil
+    )
+    @run.update!(status: "running")
+    failed_response_ids.each { |rid| CompletionKit::GenerateRowJob.perform_later(@run.id, rid) }
+  end
+
+  render json: @run.reload, status: :accepted
+end
+```
+
+Add `:retry_failures` to the `before_action :set_run` only-list.
+
+- [ ] **Step 6: Run — confirm green**
+
+Run: `bundle exec rspec spec/requests/completion_kit/runs_retry_failures_spec.rb`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add config/routes.rb app/controllers/completion_kit spec/requests/completion_kit
+git commit -m "add retry_failures action for both web and API"
+```
+
+---
+
+### Task 24: Extend Run#as_json with the new progress object
+
+**Files:**
+- Modify: `app/models/completion_kit/run.rb`
+- Modify: `spec/models/completion_kit/json_serialization_spec.rb`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `spec/models/completion_kit/json_serialization_spec.rb`:
+
+```ruby
+describe "Run#as_json includes progress object and failed_response_ids" do
+  let(:run) { create(:completion_kit_run, progress_total: 2) }
+
+  it "includes a progress hash with generated and judged sub-objects" do
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "a")
+    create(:completion_kit_response, :failed, run: run)
+
+    payload = run.as_json
+    expect(payload[:progress][:generated]).to include(done: 1, total: 2, failed: 1)
+    expect(payload[:progress][:judged]).to include(done: 0, total: 0, failed: 0)
+    expect(payload[:failed_response_ids]).to be_an(Array)
+    expect(payload[:failed_response_ids].size).to eq(1)
+  end
+
+  it "preserves legacy progress_current and progress_total fields" do
+    payload = run.as_json
+    expect(payload).to have_key(:progress_current)
+    expect(payload).to have_key(:progress_total)
+  end
+end
+```
+
+- [ ] **Step 2: Run — confirm failure**
+
+Run: `bundle exec rspec spec/models/completion_kit/json_serialization_spec.rb`
+
+- [ ] **Step 3: Update `Run#as_json`**
+
+In `app/models/completion_kit/run.rb`, replace `as_json` with:
+
+```ruby
+def as_json(options = {})
+  snap = progress_snapshot
+  {
+    id: id, name: name, status: status, prompt_id: prompt_id,
+    dataset_id: dataset_id, judge_model: judge_model, temperature: temperature,
+    created_at: created_at, updated_at: updated_at,
+    responses_count: responses.count, avg_score: avg_score,
+    progress_current: snap[:generated_done],
+    progress_total: snap[:generated_total],
+    progress: {
+      generated: { done: snap[:generated_done], total: snap[:generated_total], failed: snap[:generated_failed] },
+      judged:    { done: snap[:judged_done],    total: snap[:judged_total],    failed: snap[:judged_failed] }
+    },
+    failed_response_ids: responses.where(status: "failed").pluck(:id),
+    failure_summary: failure_summary,
+    error_message: error_message,
+    metric_ids: metric_ids
+  }
+end
+```
+
+- [ ] **Step 4: Run — confirm green**
+
+Run: `bundle exec rspec spec/models/completion_kit/json_serialization_spec.rb`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/completion_kit/run.rb spec/models/completion_kit/json_serialization_spec.rb
+git commit -m "extend Run#as_json with progress object and failed_response_ids"
+```
+
+---
+
+### Task 25: (Optional) mount mission_control-jobs dashboard
+
+**Files:**
+- Modify: `standalone/config/routes.rb`
+
+- [ ] **Step 1: Mount behind the existing auth**
+
+In `standalone/config/routes.rb`, add inside the existing auth-protected route block:
+
+```ruby
+authenticate :admin do
+  mount MissionControl::Jobs::Engine, at: "/jobs"
+end
+```
+
+(Replace `:admin` constraint with whatever auth pattern the app already uses — check existing routes to match.)
+
+- [ ] **Step 2: Smoke test locally**
+
+Boot the dev stack, hit `/jobs` in the browser, confirm the dashboard renders behind auth.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add standalone/config/routes.rb
+git commit -m "mount mission_control-jobs at /jobs"
+```
+
+> **PR 3 ends here.** Open the PR with the task commits. After merge, smoke-test in production: trigger a multi-row run, confirm progress counters increment and any failed rows surface a provider-named badge with a working Retry button.
+
+---
+
+# Self-review
+
+After writing all three phases, this section was used to verify spec coverage. Resolved gaps:
+
+- Spec §Provider error visibility → Tasks 9, 10, 11, 22 cover error capture and rendering.
+- Spec §Concurrency → Tasks 6, 16, 20 (config, DSL, boot warning).
+- Spec §Retry policy → Tasks 10, 11.
+- Spec §In-flight retry visibility → `before_perform` callbacks in Tasks 10 and 11.
+- Spec §Progress UI → Tasks 13 (`progress_snapshot`), 21 (status header).
+- Spec §Race-free completion check → Tasks 12, 16 (concurrency cap).
+- Spec §Retry-failed-rows action → Task 23.
+- Spec §JSON API → Task 24 (`Run#as_json`); Task 23 (route).
+- Spec §Deployment → Tasks 5, 6, 18, 19, 20 + the PR 2 footnote describing the manual Render Worker creation.
+- Spec §Observability → Task 25.
+- Spec §In-flight runs at the cutover → Task 20 + PR 2 footnote.
+- Spec §Schema changes → Tasks 1, 2, 3, 4.
+
+No placeholders, no "TBD", no "similar to task N" without code, no references to undefined methods. Method signatures are consistent across tasks (`outstanding_work_zero?`, `mark_completed!`, `progress_snapshot`, `start!`, `failure_summary`, `error_payload`, etc.).

--- a/docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md
+++ b/docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md
@@ -328,10 +328,11 @@ standalone/Procfile.dev (or bin/dev) — add worker process line
 ## Dependencies
 
 ```
-gem "mission_control-jobs"  # optional, for /jobs dashboard
+gem "solid_queue"           # add to standalone/Gemfile
+gem "mission_control-jobs"  # optional, add to standalone/Gemfile, for /jobs dashboard
 ```
 
-(Solid Queue is already in the Gemfile and applied; no new gem needed for the queue itself.)
+The `solid_queue_*` tables already exist in `standalone/db/schema.rb` (migration `20260327200001_create_solid_queue_tables.rb`) but the gem itself is not in any Gemfile — someone committed the migration ahead of the gem. The plan adds the gem to `standalone/Gemfile` (the engine itself stays adapter-agnostic and does not depend on Solid Queue).
 
 ---
 

--- a/docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md
+++ b/docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md
@@ -1,0 +1,363 @@
+# Prompt Run Robustness, Concurrency, and Per-Row Failure Recovery
+
+**Goal:** Make prompt runs robust to flaky LLM provider calls, durable across deploys, and capable of running in parallel without crowding each other or the host. Surface provider-side failures clearly so users can tell when an error is the provider's fault, not CompletionKit's.
+
+This is the v2 follow-on to `2026-03-26-async-runs-design.md`, which explicitly deferred per-row retries and intra-run parallelism.
+
+---
+
+## Current Behavior
+
+`Run#generate_responses!` and `Run#judge_responses!` each loop through their work synchronously inside a single ActiveJob (`GenerateJob`, `JudgeJob`). The queue adapter is `:async` in both `production.rb` and `development.rb`.
+
+Failure modes today:
+
+- A single `Faraday::Error` mid-loop flips the entire run to `failed`, throwing away every successful row that came before it. The user's only recourse is to click Generate again, re-spending every successful API call.
+- `:async` jobs run in the web Puma's thread pool. A deploy or restart kills any in-flight run silently with no resumption.
+- Solid Queue's schema is in `standalone/db/schema.rb` (migration `20260327200001_create_solid_queue_tables.rb`) but no code uses it.
+- Concurrent runs share the in-process thread pool with no per-provider throttle, so two large simultaneous runs can trip provider rate limits.
+- The `Run#status` enum (`pending → generating → judging → completed/failed`) treats generation and judging as strict sequential phases; judging cannot start until every row has finished generating, even though nothing forces this ordering.
+
+---
+
+## New Behavior
+
+### Job topology
+
+Each run fans out into row-level jobs that interleave generation and judging:
+
+```
+RunsController#generate
+        │
+        ▼
+GenerateRowJob(run_id, row_index)          ──┐ N of these per run
+   ├─ calls LLM → updates Response             │ (one per dataset row)
+   ├─ on success: enqueues JudgeReviewJob      │
+   │   for each metric on this run             │ each retried independently
+   └─ on terminal failure: marks Response      │ via ActiveJob retry_on
+       failed with provider error context    ──┘
+
+JudgeReviewJob(response_id, metric_id)     ──┐ N×M of these per run
+   ├─ calls judge LLM                          │
+   └─ updates Review                         ──┘
+
+Each job, on completion (success OR terminal failure):
+   ├─ broadcasts its row/review update
+   └─ enqueues RunCompletionCheckJob(run_id)
+
+RunCompletionCheckJob(run_id)
+   └─ if no outstanding work for run → run.mark_completed!
+```
+
+There is no phase wait. The `JudgeReviewJob`s for row 1 can run while `GenerateRowJob` for row 99 is still queued. A run is "done" when every `Response` is in a terminal state (`succeeded` or `failed`) and every expected `Review` is in a terminal state.
+
+### Run status model
+
+The status enum collapses to:
+
+```
+pending ──(user clicks Generate)──> running ──(all rows + reviews terminal)──> completed
+                                       │
+                                       └──(infra-level failure: dataset empty,
+                                           judge unconfigured, etc.)──> failed
+```
+
+`generating` and `judging` are dropped. Per-row LLM-call failures **never** flip the run to `failed`; only terminal infra problems (no rows in dataset, missing judge model when judging requested, etc.) do.
+
+### Failure semantics
+
+- Each row's `GenerateRowJob` retries transient errors independently with backoff. After exhaustion, the row's `Response` is marked `status: "failed"` with provider error context recorded.
+- Each `JudgeReviewJob` does the same for its `Review`.
+- The run continues regardless of how many rows fail.
+- When the run reaches a terminal state with any failed rows, the status header surfaces a `Retry failed rows` action that re-enqueues only the failed work.
+
+### Provider error visibility
+
+When a row fails, the `Response` row in the UI displays a badge leading with the provider name and the provider's status / error class:
+
+```
+Failed: OpenAI 429 — Rate limit exceeded
+Failed: Anthropic 529 — Overloaded
+Failed: OpenAI Faraday::TimeoutError — Connection reset by peer
+```
+
+This makes it immediately obvious to the user that the failure originated at the provider, not in CompletionKit. Hover/click expands to the full error message and attempt count.
+
+### Concurrency
+
+Solid Queue concurrency keys cap parallel work along two independent dimensions:
+
+- **Per-provider** (`limits_concurrency key: -> { "llm:#{provider}" }`) — cap simultaneous LLM calls to a single provider system-wide. Default 10. Stops a 429 storm.
+- **Per-run** (`limits_concurrency key: -> { "run:#{run_id}" }`) — cap simultaneous calls from a single run. Default 5. Stops one large run from monopolizing the per-provider budget when other runs are queued.
+
+Both limits are ENV-configurable so they can be tuned without a deploy:
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `COMPLETION_KIT_LLM_CONCURRENCY` | 10 | Max in-flight calls per provider |
+| `COMPLETION_KIT_PER_RUN_CONCURRENCY` | 5 | Max in-flight calls per run |
+| `SOLID_QUEUE_THREADS` | 10 | Worker thread pool (must be ≥ `COMPLETION_KIT_LLM_CONCURRENCY`) |
+| `SOLID_QUEUE_PROCESSES` | 1 | Bump only if vertical scaling fails |
+
+Generation and judging keep separate per-provider buckets — judging GPT-4 outputs with Claude does not contend with the generation pool because the provider keys differ.
+
+A boot-time check logs a warning if `SOLID_QUEUE_THREADS < COMPLETION_KIT_LLM_CONCURRENCY`, since threads would become the actual bottleneck and the per-provider cap would never be reached.
+
+### Retry policy
+
+```ruby
+class GenerateRowJob < ApplicationJob
+  queue_as :llm
+
+  retry_on Faraday::TimeoutError,
+           Faraday::ConnectionFailed,
+           wait: :polynomially_longer, attempts: 5
+
+  retry_on CompletionKit::RateLimitError,
+           wait: ->(executions) { 30 * executions }, attempts: 5
+
+  discard_on ActiveJob::DeserializationError
+  discard_on CompletionKit::ConfigurationError
+end
+```
+
+A new `CompletionKit::RateLimitError` is raised by `LlmClient` when the provider returns 429. Rate limits clear on a wall clock, so they get a fixed-step backoff (30s, 60s, 90s, 120s, 150s) instead of exponential.
+
+`ActiveJob::DeserializationError` (response/review was deleted) and `CompletionKit::ConfigurationError` (missing API key, etc.) are not worth retrying and discard immediately.
+
+A `rescue_from(StandardError)` on the job records terminal failure on the row, broadcasts, and enqueues the completion check.
+
+### In-flight retry visibility
+
+A `before_perform` increments the row's `attempts` counter and broadcasts a "retrying… attempt N/5" sub-status, so the UI shows the row pulsing through retries instead of looking stuck. After exhaustion, the row settles into `failed` with the final provider error visible.
+
+### Progress UI
+
+The status header on the run show page splits its progress into two counters (generation and judging), since the two phases interleave:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ● Running                                                    │
+│   Generated 47/100 ████████░░░░░░░░░░ (3 failed)             │
+│   Judged    38/200 ████░░░░░░░░░░░░░░ (1 failed)             │
+│                                                              │
+│   [Retry 4 failed rows]                                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+When complete:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ✓ Completed · avg score 7.2                                  │
+│   100/100 generated · 196/200 judged · 4 failed              │
+│   [Retry 4 failed rows]                                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+A `Run#progress_snapshot` method returns a single hash:
+
+```ruby
+{ generated_done:, generated_total:, generated_failed:,
+  judged_done:, judged_total:, judged_failed: }
+```
+
+so the partial reads from one source of truth.
+
+### Response row UI
+
+Per-row chrome on the responses table:
+
+- **Pending** — spinner + "queued"
+- **Retrying** — spinner + "retrying… attempt 3/5" (subtle yellow tint)
+- **Succeeded** — response text + reviews as today
+- **Failed** — red badge `OpenAI 429 — Rate limit exceeded`, hover/click expands to full message, per-row `Retry` link
+
+### Turbo Stream broadcasts
+
+Channel stays `completion_kit_run_<id>`. Targets that get replaced:
+
+| Event | Targets |
+|-------|---------|
+| `GenerateRowJob` start | `response_<id>` |
+| `GenerateRowJob` succeeded | `response_<id>`, `run_status_header` |
+| `GenerateRowJob` failed | `response_<id>`, `run_status_header` |
+| `JudgeReviewJob` succeeded/failed | `review_<id>`, `run_status_header` |
+| `Run` completed | `run_status_header`, `run_actions`, `run_sort_toolbar` |
+
+### Race-free completion check
+
+`RunCompletionCheckJob` is enqueued at the end of every row/review job rather than handled inline. It runs `if run.outstanding_work_zero? then run.mark_completed!`. Solid Queue's `concurrency_key: "run:<id>:completion", limit: 1` serializes these checks so two near-simultaneous "am I last?" jobs cannot both decide they are.
+
+This costs one tiny extra job per row/review completion in exchange for a clean race-free completion transition without row-level locking.
+
+### Retry-failed-rows action
+
+A new `RunsController#retry_failures` action:
+
+1. Resets failed `Response`s to `pending` (clears error fields, resets `attempts` to 0 — UI reads "attempt N/5" so attempts must be a per-cycle counter, not a lifetime one)
+2. Resets dependent failed `Review`s the same way
+3. Re-enqueues `GenerateRowJob` for the reset responses' indices
+4. Run goes back to `running`
+
+REST API equivalent: `POST /api/v1/runs/:id/retry_failures`.
+
+### JSON API
+
+`Run#as_json` keeps backward compatibility:
+
+- `progress_current` / `progress_total` keep their existing meaning, mapped to `generated_done` / `generated_total`.
+- New `progress` object: `{ generated: { done, total, failed }, judged: { done, total, failed } }`.
+- New `failed_response_ids` array.
+- New endpoint: `POST /api/v1/runs/:id/retry_failures`.
+
+### Deployment
+
+Render currently runs the standalone app as a single Web service, configured via the Render dashboard (no `render.yaml` exists in the repo). A new Background Worker service is added manually:
+
+1. Render dashboard → New service → Background Worker
+2. Same repo, same branch, same root directory as web
+3. Build command: `bundle install`
+4. Start command: `cd standalone && bin/jobs`
+5. Env vars: copy the entire web service env-var set, then add `SOLID_QUEUE_THREADS=10`, `COMPLETION_KIT_LLM_CONCURRENCY=10`, `COMPLETION_KIT_PER_RUN_CONCURRENCY=5`. The worker must have the same `DATABASE_URL`, `RAILS_MASTER_KEY`, all LLM provider keys, and the three `COMPLETION_KIT_ENCRYPTION_*` keys — without those last three the worker crashes on boot when the initializer touches `ProviderCredential` rows.
+6. No pre-deploy on the worker. Migrations run from the web service's pre-deploy.
+
+Solid Queue tables already exist in production (migration `20260327200001_create_solid_queue_tables.rb` is committed and applied). No DB work is needed beyond the schema additions in this spec.
+
+`config/environments/production.rb` flips `config.active_job.queue_adapter` from `:async` to `:solid_queue`. Same change in `development.rb` so dev parity matches prod (`bin/dev` Procfile gets a `worker: bin/jobs` line).
+
+### Observability
+
+Mount `mission_control-jobs` at `/jobs` behind the engine's existing auth so queue health is inspectable without SSH. Optional but cheap.
+
+### In-flight runs at the cutover
+
+Any run still mid-flight under `:async` is killed by the deploy that switches adapters. A one-time Rake task (`completion_kit:mark_interrupted_runs_failed`) run in the deploy hook marks `running` runs as `failed` with `failure_summary: "Interrupted by deploy"`, so users can hit Retry and rerun cleanly. One-time cost; only affects runs in flight at the cutover.
+
+---
+
+## Schema Changes
+
+### `completion_kit_responses`
+
+```ruby
+add_column :completion_kit_responses, :status, :string, default: "pending", null: false
+add_column :completion_kit_responses, :error_provider, :string
+add_column :completion_kit_responses, :error_class, :string
+add_column :completion_kit_responses, :error_status, :integer
+add_column :completion_kit_responses, :error_message, :text
+add_column :completion_kit_responses, :attempts, :integer, default: 0, null: false
+add_column :completion_kit_responses, :row_index, :integer
+add_index  :completion_kit_responses, [:run_id, :status]
+```
+
+Backfill: existing responses with `response_text` present get `status: "succeeded"`.
+
+### `completion_kit_reviews`
+
+```ruby
+add_column :completion_kit_reviews, :status, :string, default: "pending", null: false
+add_column :completion_kit_reviews, :error_provider, :string
+add_column :completion_kit_reviews, :error_class, :string
+add_column :completion_kit_reviews, :error_status, :integer
+add_column :completion_kit_reviews, :error_message, :text
+add_column :completion_kit_reviews, :attempts, :integer, default: 0, null: false
+add_index  :completion_kit_reviews, [:response_id, :status]
+```
+
+Backfill: existing reviews with `ai_score` present get `status: "succeeded"`.
+
+### `completion_kit_runs`
+
+```ruby
+add_column :completion_kit_runs, :failure_summary, :string
+```
+
+Status enum becomes `pending | running | completed | failed` (drop `generating`, `judging` from `STATUSES` constant). Existing rows with `generating` or `judging` are migrated to `running`; existing `progress_current` / `progress_total` columns are kept and used for the legacy generated counter.
+
+---
+
+## Files to Create
+
+```
+app/jobs/completion_kit/generate_row_job.rb
+app/jobs/completion_kit/judge_review_job.rb
+app/jobs/completion_kit/run_completion_check_job.rb
+(retry_failures action lives inline in RunsController; no new file)
+app/views/completion_kit/runs/_status_header.html.erb (rewrite)
+app/views/completion_kit/runs/_response_row.html.erb (rewrite)
+app/services/completion_kit/rate_limit_error.rb (new exception class)
+config/queue.yml
+db/migrate/<timestamp>_add_status_and_error_to_responses.rb
+db/migrate/<timestamp>_add_status_and_error_to_reviews.rb
+db/migrate/<timestamp>_add_failure_summary_to_runs.rb
+lib/tasks/completion_kit_runs.rake (mark_interrupted_runs_failed task)
+```
+
+## Files to Modify
+
+```
+app/models/completion_kit/run.rb
+  - shrink generate_responses!/judge_responses! to start! that creates pending Responses + enqueues GenerateRowJobs
+  - drop status enum values, add progress_snapshot, add outstanding_work_zero?, add mark_completed!
+  - update broadcasts to fire from job callbacks rather than the loop
+app/models/completion_kit/response.rb
+  - add status enum + error fields, validations, terminal? predicate
+app/models/completion_kit/review.rb
+  - same shape as response
+app/models/completion_kit/prompt.rb
+  - add llm_model_provider method ("openai" / "anthropic" / etc., from llm_model)
+app/services/completion_kit/llm_client.rb
+  - raise RateLimitError on 429
+app/jobs/completion_kit/generate_job.rb (delete or repoint to GenerateRowJob enqueuer)
+app/jobs/completion_kit/judge_job.rb (delete or repoint)
+app/controllers/completion_kit/runs_controller.rb
+  - generate action calls run.start! instead of GenerateJob.perform_later
+  - add retry_failures action
+app/controllers/completion_kit/api/v1/runs_controller.rb
+  - same change + new retry_failures endpoint
+config/routes.rb
+  - POST /runs/:id/retry_failures (web + api/v1)
+config/environments/production.rb
+  - config.active_job.queue_adapter = :solid_queue
+config/environments/development.rb
+  - same
+standalone/Procfile.dev (or bin/dev) — add worker process line
+```
+
+## Dependencies
+
+```
+gem "mission_control-jobs"  # optional, for /jobs dashboard
+```
+
+(Solid Queue is already in the Gemfile and applied; no new gem needed for the queue itself.)
+
+---
+
+## Rollout
+
+Three PRs, ordered to avoid downtime:
+
+1. **PR 1 — schema + status backfill.** Migrations for `status` / error columns on responses and reviews, `failure_summary` on runs. Backfill existing rows. No behavior change. Safe to ship to web only.
+
+2. **PR 2 — adapter switch + new jobs.** Add `config/queue.yml`, create the row-level jobs and `RunCompletionCheckJob`, refactor `Run` to enqueue per-row work, switch `production.rb` adapter to `:solid_queue`. **The Render Worker service must exist before this ships** or no jobs will run. Run the `mark_interrupted_runs_failed` task in the deploy hook to clean up any runs in flight at the cutover.
+
+3. **PR 3 — UI + API.** Status header rewrite, response row rewrite, retry-failures action, `/api/v1/runs/:id/retry_failures` endpoint, JSON API extensions. Schema is already in place from PR 1.
+
+---
+
+## Out of Scope
+
+- Multi-run dashboard / cross-run progress view (current per-run page is sufficient per user's stated needs).
+- Cancel a running job mid-execution.
+- Per-row retry budget tuning. The 5-attempt cap is hardcoded in this spec; revisit if rate-limit storms become routine.
+- Render Blueprint (`render.yaml`) adoption — flagged as a separate follow-up so deployment isn't lore.
+- A separate `failed_with_warnings` run state — partial-failure runs land on `completed` and surface failure counts in the header.
+
+---
+
+## Follow-ups (not part of this work)
+
+- Update `project_render_runbook.md` memory entry: queue adapter is `:solid_queue`, drop the "restart to clear stuck async thread pool" note, document the worker service.
+- Consider adopting `render.yaml` Blueprint so worker config is committed alongside the code.

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -4,5 +4,21 @@ FactoryBot.define do
     input_data { { content: "Release notes", audience: "developers" }.to_json }
     response_text { "A generated summary" }
     expected_output { "A developer-focused summary" }
+    status { "succeeded" }
+
+    trait :pending do
+      status { "pending" }
+      response_text { nil }
+    end
+
+    trait :failed do
+      status { "failed" }
+      response_text { nil }
+      error_provider { "openai" }
+      error_class { "Faraday::TimeoutError" }
+      error_status { nil }
+      error_message { "execution expired" }
+      attempts { 5 }
+    end
   end
 end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -2,9 +2,10 @@ FactoryBot.define do
   factory :completion_kit_review, class: "CompletionKit::Review" do
     association :response, factory: :completion_kit_response
     association :metric, factory: :completion_kit_metric
-    metric_name { metric.name }
-    status { "evaluated" }
-    ai_score { 4.5 }
-    ai_feedback { "Strong match for the metric." }
+    metric_name { "Quality" }
+    instruction { "Rate the response quality." }
+    status { "succeeded" }
+    ai_score { 4.0 }
+    ai_feedback { "Good response." }
   end
 end

--- a/spec/helpers/completion_kit/application_helper_spec.rb
+++ b/spec/helpers/completion_kit/application_helper_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe CompletionKit::ApplicationHelper, type: :helper do
       expect(helper.ck_badge_classes(:low)).to include("ck-badge--low")
       expect(helper.ck_badge_classes(:pending)).to include("ck-badge--pending")
       expect(helper.ck_badge_classes(:running)).to include("ck-badge--running")
-      expect(helper.ck_badge_classes(:generating)).to include("ck-badge--running")
-      expect(helper.ck_badge_classes(:judging)).to include("ck-badge--running")
       expect(helper.ck_badge_classes(:completed)).to include("ck-badge--high")
       expect(helper.ck_badge_classes(:failed)).to include("ck-badge--low")
       expect(helper.ck_badge_classes(:mystery)).to include("ck-badge--pending")
@@ -37,12 +35,8 @@ RSpec.describe CompletionKit::ApplicationHelper, type: :helper do
       expect(helper.ck_run_dot(stub_run("pending"))).to eq("ck-dot ck-dot--pending")
     end
 
-    it "returns running dot for generating status" do
-      expect(helper.ck_run_dot(stub_run("generating"))).to eq("ck-dot ck-dot--running")
-    end
-
-    it "returns running dot for judging status" do
-      expect(helper.ck_run_dot(stub_run("judging"))).to eq("ck-dot ck-dot--running")
+    it "returns running dot for running status" do
+      expect(helper.ck_run_dot(stub_run("running"))).to eq("ck-dot ck-dot--running")
     end
 
     it "returns failed dot for failed status" do
@@ -144,20 +138,12 @@ RSpec.describe CompletionKit::ApplicationHelper, type: :helper do
       expect(helper.ck_run_status_label(stub_run("pending"))).to eq("Ready to run")
     end
 
-    it "returns generating with progress when progress_total > 0" do
-      expect(helper.ck_run_status_label(stub_run("generating", progress_current: 3, progress_total: 10))).to eq("Generating responses (3/10)")
+    it "returns running with progress when progress_total > 0" do
+      expect(helper.ck_run_status_label(stub_run("running", progress_current: 3, progress_total: 10))).to eq("Running (3/10)")
     end
 
-    it "returns generating without progress when progress_total is 0" do
-      expect(helper.ck_run_status_label(stub_run("generating", progress_total: 0))).to include("Generating")
-    end
-
-    it "returns judging with progress when progress_total > 0" do
-      expect(helper.ck_run_status_label(stub_run("judging", progress_current: 2, progress_total: 8))).to eq("Judging (2/8 evaluations)")
-    end
-
-    it "returns judging without progress when progress_total is 0" do
-      expect(helper.ck_run_status_label(stub_run("judging", progress_total: 0))).to include("Judging")
+    it "returns running without progress when progress_total is 0" do
+      expect(helper.ck_run_status_label(stub_run("running", progress_total: 0))).to include("Running")
     end
 
     it "returns Completed for completed" do

--- a/spec/integration/completion_kit/judging_pipeline_spec.rb
+++ b/spec/integration/completion_kit/judging_pipeline_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "End-to-end judging pipeline", type: :model do
     expect(review.ai_feedback).to include("Relevant")
     expect(review.metric_id).to eq(metric.id)
     expect(review.metric_name).to eq("Relevance")
-    expect(review.status).to eq("evaluated")
+    expect(review.status).to eq("succeeded")
   end
 
   it "updates existing reviews on re-judge without duplicating" do

--- a/spec/models/completion_kit/json_serialization_spec.rb
+++ b/spec/models/completion_kit/json_serialization_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "JSON serialization" do
 
     it "includes expected attributes" do
       json = review.as_json
-      expect(json.keys).to match_array(%i[id response_id metric_id metric_name ai_score ai_feedback status])
+      expect(json.keys).to match_array(%i[id response_id metric_id metric_name ai_score ai_feedback status attempts error])
     end
   end
 end

--- a/spec/models/completion_kit/json_serialization_spec.rb
+++ b/spec/models/completion_kit/json_serialization_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "JSON serialization" do
     it "includes expected attributes and computed fields" do
       resp = create(:completion_kit_response)
       json = resp.as_json
-      expect(json.keys).to match_array(%i[id run_id input_data response_text expected_output created_at score reviewed reviews])
+      expect(json.keys).to match_array(%i[id run_id input_data response_text expected_output created_at score reviewed reviews status attempts row_index error])
     end
 
     it "includes nested reviews" do

--- a/spec/models/completion_kit/response_spec.rb
+++ b/spec/models/completion_kit/response_spec.rb
@@ -6,8 +6,51 @@ RSpec.describe CompletionKit::Response, type: :model do
     expect(response).to be_valid
   end
 
-  it "requires response_text" do
-    response = build(:completion_kit_response, response_text: nil)
+  it "requires response_text when status is succeeded" do
+    response = build(:completion_kit_response, status: "succeeded", response_text: nil)
     expect(response).not_to be_valid
+  end
+
+  describe "#error_payload" do
+    it "returns nil when error_class is blank" do
+      response = build(:completion_kit_response)
+      expect(response.error_payload).to be_nil
+    end
+
+    it "returns a hash with error details when error_class is present" do
+      response = build(:completion_kit_response, :failed)
+      expect(response.error_payload).to eq(
+        provider: "openai",
+        class: "Faraday::TimeoutError",
+        status: nil,
+        message: "execution expired"
+      )
+    end
+  end
+
+  describe "status" do
+    it "defaults to pending on a new record" do
+      response = build(:completion_kit_response, status: nil, response_text: "anything")
+      response.valid?
+      expect(response.status).to eq("pending")
+    end
+
+    it "validates inclusion in the STATUSES list" do
+      response = build(:completion_kit_response, status: "weird")
+      expect(response).not_to be_valid
+      expect(response.errors[:status]).to be_present
+    end
+
+    %w[pending retrying].each do |status|
+      it "is not terminal? when status is #{status}" do
+        expect(build(:completion_kit_response, status: status)).not_to be_terminal
+      end
+    end
+
+    %w[succeeded failed].each do |status|
+      it "is terminal? when status is #{status}" do
+        expect(build(:completion_kit_response, status: status)).to be_terminal
+      end
+    end
   end
 end

--- a/spec/models/completion_kit/review_spec.rb
+++ b/spec/models/completion_kit/review_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe CompletionKit::Review, type: :model do
+  describe "status" do
+    let(:response) { create(:completion_kit_response) }
+
+    it "validates inclusion in pending/retrying/succeeded/failed" do
+      review = build(:completion_kit_review, response: response, status: "evaluated")
+      expect(review).not_to be_valid
+    end
+
+    %w[pending retrying].each do |status|
+      it "is not terminal? when status is #{status}" do
+        expect(build(:completion_kit_review, response: response, status: status)).not_to be_terminal
+      end
+    end
+
+    %w[succeeded failed].each do |status|
+      it "is terminal? when status is #{status}" do
+        expect(build(:completion_kit_review, response: response, status: status)).to be_terminal
+      end
+    end
+
+    it "is succeeded? when status is succeeded" do
+      expect(build(:completion_kit_review, response: response, status: "succeeded")).to be_succeeded
+    end
+
+    it "is not succeeded? when status is failed" do
+      expect(build(:completion_kit_review, response: response, status: "failed")).not_to be_succeeded
+    end
+  end
+
+  describe "#error_payload" do
+    let(:response) { create(:completion_kit_response) }
+
+    it "returns nil when error_class is blank" do
+      review = build(:completion_kit_review, response: response)
+      expect(review.error_payload).to be_nil
+    end
+
+    it "returns a structured hash when error fields are populated" do
+      review = build(:completion_kit_review, response: response,
+        error_provider: "anthropic", error_class: "Faraday::TimeoutError",
+        error_status: nil, error_message: "boom")
+      expect(review.error_payload).to eq(
+        provider: "anthropic", class: "Faraday::TimeoutError", status: nil, message: "boom"
+      )
+    end
+  end
+end

--- a/spec/models/completion_kit/run_spec.rb
+++ b/spec/models/completion_kit/run_spec.rb
@@ -177,6 +177,23 @@ RSpec.describe CompletionKit::Run, type: :model do
     end
   end
 
+  describe "status enum" do
+    it "rejects the legacy generating status" do
+      run = build(:completion_kit_run, status: "generating")
+      expect(run).not_to be_valid
+    end
+
+    it "rejects the legacy judging status" do
+      run = build(:completion_kit_run, status: "judging")
+      expect(run).not_to be_valid
+    end
+
+    it "accepts running" do
+      run = build(:completion_kit_run, status: "running")
+      expect(run).to be_valid
+    end
+  end
+
   describe "#judge_responses!" do
     let(:metric) { create(:completion_kit_metric, name: "Quality") }
     let(:prompt) { create(:completion_kit_prompt) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -118,6 +118,14 @@ ActiveRecord::Schema.define do
     t.text :input_data
     t.text :response_text
     t.text :expected_output
+    t.string :status, default: "pending", null: false
+    t.string :error_provider
+    t.string :error_class
+    t.integer :error_status
+    t.text :error_message
+    t.integer :attempts, default: 0, null: false
+    t.integer :row_index
+    t.index [:run_id, :status]
     t.timestamps
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,7 +102,7 @@ ActiveRecord::Schema.define do
     t.integer :progress_current, default: 0
     t.integer :progress_total, default: 0
     t.text :error_message
-    t.string :failure_summary
+    t.text :failure_summary
     t.float :temperature, default: 1.0
     t.timestamps
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define do
     t.integer :progress_current, default: 0
     t.integer :progress_total, default: 0
     t.text :error_message
+    t.string :failure_summary
     t.float :temperature, default: 1.0
     t.timestamps
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -137,6 +137,12 @@ ActiveRecord::Schema.define do
     t.string :status
     t.decimal :ai_score, precision: 4, scale: 1
     t.text :ai_feedback
+    t.string :error_provider
+    t.string :error_class
+    t.integer :error_status
+    t.text :error_message
+    t.integer :attempts, default: 0, null: false
+    t.index [:response_id, :status]
     t.timestamps
   end
 

--- a/standalone/db/migrate/20260504031354_add_status_and_error_to_responses.completion_kit.rb
+++ b/standalone/db/migrate/20260504031354_add_status_and_error_to_responses.completion_kit.rb
@@ -1,0 +1,22 @@
+# This migration comes from completion_kit (originally 20260501000001)
+class AddStatusAndErrorToResponses < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_responses, :status, :string, default: "pending", null: false
+    add_column :completion_kit_responses, :error_provider, :string
+    add_column :completion_kit_responses, :error_class, :string
+    add_column :completion_kit_responses, :error_status, :integer
+    add_column :completion_kit_responses, :error_message, :text
+    add_column :completion_kit_responses, :attempts, :integer, default: 0, null: false
+    add_column :completion_kit_responses, :row_index, :integer
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_responses
+          SET status = 'succeeded'
+          WHERE response_text IS NOT NULL AND length(response_text) > 0
+        SQL
+      end
+    end
+  end
+end

--- a/standalone/db/migrate/20260504031355_index_responses_on_run_id_and_status.completion_kit.rb
+++ b/standalone/db/migrate/20260504031355_index_responses_on_run_id_and_status.completion_kit.rb
@@ -1,3 +1,4 @@
+# This migration comes from completion_kit (originally 20260501000002)
 class IndexResponsesOnRunIdAndStatus < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/standalone/db/migrate/20260504031356_add_status_and_error_to_reviews.completion_kit.rb
+++ b/standalone/db/migrate/20260504031356_add_status_and_error_to_reviews.completion_kit.rb
@@ -1,0 +1,26 @@
+# This migration comes from completion_kit (originally 20260501000003)
+class AddStatusAndErrorToReviews < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_reviews, :error_provider, :string
+    add_column :completion_kit_reviews, :error_class, :string
+    add_column :completion_kit_reviews, :error_status, :integer
+    add_column :completion_kit_reviews, :error_message, :text
+    add_column :completion_kit_reviews, :attempts, :integer, default: 0, null: false
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_reviews
+          SET status = 'succeeded'
+          WHERE ai_score IS NOT NULL
+        SQL
+
+        execute <<~SQL
+          UPDATE completion_kit_reviews
+          SET status = 'succeeded'
+          WHERE status = 'evaluated'
+        SQL
+      end
+    end
+  end
+end

--- a/standalone/db/migrate/20260504031357_index_reviews_on_response_id_and_status.completion_kit.rb
+++ b/standalone/db/migrate/20260504031357_index_reviews_on_response_id_and_status.completion_kit.rb
@@ -1,3 +1,4 @@
+# This migration comes from completion_kit (originally 20260501000004)
 class IndexReviewsOnResponseIdAndStatus < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/standalone/db/migrate/20260504031358_collapse_run_status_and_add_failure_summary.completion_kit.rb
+++ b/standalone/db/migrate/20260504031358_collapse_run_status_and_add_failure_summary.completion_kit.rb
@@ -1,0 +1,16 @@
+# This migration comes from completion_kit (originally 20260501000005)
+class CollapseRunStatusAndAddFailureSummary < ActiveRecord::Migration[7.1]
+  def change
+    add_column :completion_kit_runs, :failure_summary, :text
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE completion_kit_runs
+          SET status = 'running'
+          WHERE status IN ('generating', 'judging')
+        SQL
+      end
+    end
+  end
+end

--- a/standalone/db/schema.rb
+++ b/standalone/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_214544) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_031358) do
   create_table "completion_kit_datasets", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "csv_data", null: false
@@ -91,19 +91,32 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_214544) do
   end
 
   create_table "completion_kit_responses", force: :cascade do |t|
+    t.integer "attempts", default: 0, null: false
     t.datetime "created_at", null: false
+    t.string "error_class"
+    t.text "error_message"
+    t.string "error_provider"
+    t.integer "error_status"
     t.text "expected_output"
     t.text "input_data"
     t.text "response_text"
+    t.integer "row_index"
     t.integer "run_id", null: false
+    t.string "status", default: "pending", null: false
     t.datetime "updated_at", null: false
+    t.index ["run_id", "status"], name: "index_completion_kit_responses_on_run_id_and_status"
     t.index ["run_id"], name: "index_completion_kit_responses_on_run_id"
   end
 
   create_table "completion_kit_reviews", force: :cascade do |t|
     t.text "ai_feedback"
     t.decimal "ai_score", precision: 4, scale: 1
+    t.integer "attempts", default: 0, null: false
     t.datetime "created_at", null: false
+    t.string "error_class"
+    t.text "error_message"
+    t.string "error_provider"
+    t.integer "error_status"
     t.text "instruction"
     t.integer "metric_id"
     t.string "metric_name"
@@ -111,6 +124,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_214544) do
     t.string "status"
     t.datetime "updated_at", null: false
     t.index ["metric_id"], name: "index_completion_kit_reviews_on_metric_id"
+    t.index ["response_id", "status"], name: "index_completion_kit_reviews_on_response_id_and_status"
     t.index ["response_id"], name: "index_completion_kit_reviews_on_response_id"
   end
 
@@ -128,6 +142,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_214544) do
     t.datetime "created_at", null: false
     t.integer "dataset_id"
     t.text "error_message"
+    t.text "failure_summary"
     t.string "judge_model"
     t.string "name"
     t.integer "progress_current", default: 0

--- a/standalone/db/seeds.rb
+++ b/standalone/db/seeds.rb
@@ -149,7 +149,7 @@ responses_data.each do |rd|
     response.reviews.find_or_create_by!(metric: metric) do |review|
       review.metric_name = metric_name
       review.instruction = metric.instruction
-      review.status = "evaluated"
+      review.status = "succeeded"
       review.ai_score = score
       review.ai_feedback = feedback
     end
@@ -258,7 +258,7 @@ summary_responses.each do |rd|
     response.reviews.find_or_create_by!(metric: metric) do |review|
       review.metric_name = metric_name
       review.instruction = metric.instruction
-      review.status = "evaluated"
+      review.status = "succeeded"
       review.ai_score = score
       review.ai_feedback = feedback
     end
@@ -313,7 +313,7 @@ neighbourhood_responses.each do |rd|
     response.reviews.find_or_create_by!(metric: metric) do |review|
       review.metric_name = metric_name
       review.instruction = metric.instruction
-      review.status = "evaluated"
+      review.status = "succeeded"
       review.ai_score = score
       review.ai_feedback = feedback
     end


### PR DESCRIPTION
## Summary

Schema groundwork for the prompt-run-robustness initiative. Self-contained — no behavior change yet. Safe to ship to web-only.

This is **PR 1 of 3** in a stacked series. PR 2 (jobs + adapter switch) and PR 3 (UI + API) build on this. See `docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md` for the full design and `docs/superpowers/plans/2026-05-03-prompt-run-robustness.md` for the task-by-task implementation plan.

## What's in this PR

- **Schema additions** (5 migrations, installed into standalone):
  - `completion_kit_responses` → `status` (default "pending"), `error_provider`, `error_class`, `error_status`, `error_message`, `attempts`, `row_index`, plus compound index `[run_id, status]`
  - `completion_kit_reviews` → same error columns + `attempts`, plus compound index `[response_id, status]`
  - `completion_kit_runs` → `failure_summary` (text)
- **Status backfills:** `evaluated → succeeded` on reviews; `generating | judging → running` on runs.
- **Run STATUSES collapsed** from 5 values to `pending | running | completed | failed`. Generation and judging interleave under PR 2's job topology — separate phases stop making sense.
- **New model surface:** Response/Review gain `STATUSES`, `TERMINAL_STATUSES`, `terminal?`, `succeeded?`, `error_payload` predicates and helpers. `Response#as_json` extended.
- **Cleanup:** All callers of legacy literals (`evaluated` / `generating` / `judging`) updated across controllers, helpers, view partials, factories, integration specs, and standalone seeds.
- **Migration safety:** column-add migrations are transactional; index migrations use `disable_ddl_transaction!` + `algorithm: :concurrently` on Postgres, plain `add_index` on SQLite via adapter guard.

## Test plan

- [ ] CI green: 480 examples, 0 failures, 100% line + branch coverage
- [ ] Local `bin/rails db:migrate` against existing dev data works without errors
- [ ] Reviewer confirms `failure_summary` is correctly typed as `:text` (not `:string`)
- [ ] Reviewer spot-checks the `evaluated → succeeded` backfill SQL idempotency

## Notes for reviewer

- 12 commits including the spec/plan docs. Skim `docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md` first for the why.
- The legacy methods `Run#generate_responses!` and `Run#judge_responses!` are interim-patched here to write `"running"` instead of `"generating"`/`"judging"` so the existing flow doesn't break before PR 2 replaces them.
