### PR TITLE
Prompt run robustness — Phase 3: UI + JSON API + retry-failed-rows

### DIFF
--- a/app/assets/stylesheets/completion_kit/application.css
+++ b/app/assets/stylesheets/completion_kit/application.css
@@ -385,6 +385,18 @@ tr:hover .ck-chip--publish {
   color: var(--ck-accent);
 }
 
+.ck-chip--warning {
+  background: var(--ck-warning-soft);
+  border-color: rgba(224, 164, 88, 0.3);
+  color: var(--ck-warning);
+}
+
+.ck-chip--danger {
+  background: var(--ck-danger-soft);
+  border-color: rgba(248, 113, 113, 0.3);
+  color: var(--ck-danger);
+}
+
 .ck-badge--high {
   background: var(--ck-success-soft);
   border: 1px solid rgba(34, 197, 94, 0.25);
@@ -1834,6 +1846,21 @@ select.ck-input {
 
 .ck-response-row__score {
   flex-shrink: 0;
+}
+
+.ck-response-row--pending .ck-response-row__text,
+.ck-response-row--retrying .ck-response-row__text {
+  color: var(--ck-dim);
+}
+
+.ck-response-row--failed .ck-response-row__text {
+  color: var(--ck-danger);
+  opacity: 0.8;
+}
+
+.ck-response-row__error {
+  font-family: var(--ck-mono);
+  font-size: 0.82rem;
 }
 
 .ck-score {

--- a/app/assets/stylesheets/completion_kit/application.css
+++ b/app/assets/stylesheets/completion_kit/application.css
@@ -679,6 +679,27 @@ tr:hover .ck-chip--publish {
   color: var(--ck-text);
 }
 
+.ck-progress-block {
+  padding: 0.5rem 1rem 0.75rem;
+  border-top: 1px solid var(--ck-line);
+  font-size: 0.72rem;
+  font-family: var(--ck-mono);
+  color: var(--ck-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.ck-progress-line {
+  display: flex;
+  gap: 0.4rem;
+  align-items: baseline;
+}
+
+.ck-progress-failed {
+  color: var(--ck-danger);
+}
+
 .ck-model-list-details summary {
   list-style: none;
 }

--- a/app/assets/stylesheets/completion_kit/application.css
+++ b/app/assets/stylesheets/completion_kit/application.css
@@ -274,16 +274,37 @@ form.button_to {
   color: var(--ck-accent);
 }
 
-button.ck-link {
+.ck-disclosure-toggle {
   appearance: none;
   background: transparent;
   border: 0;
   padding: 0;
-  margin: 0;
-  font: inherit;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  margin: 0.5rem 0 0;
+  font-family: var(--ck-mono);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ck-muted);
   cursor: pointer;
+  transition: color 0.15s;
+}
+
+.ck-disclosure-toggle:hover,
+.ck-disclosure-toggle:focus-visible {
+  color: var(--ck-accent);
+  outline: none;
+}
+
+.ck-disclosure-toggle::after {
+  content: " ↓";
+  display: inline-block;
+  margin-left: 0.25rem;
+  transition: transform 0.15s;
+}
+
+.ck-disclosure-toggle[aria-expanded="true"]::after {
+  transform: rotate(180deg);
 }
 
 .ck-list {

--- a/app/assets/stylesheets/completion_kit/application.css
+++ b/app/assets/stylesheets/completion_kit/application.css
@@ -274,6 +274,18 @@ form.button_to {
   color: var(--ck-accent);
 }
 
+button.ck-link {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
 .ck-list {
   display: grid;
   gap: 0.5rem;

--- a/app/assets/stylesheets/completion_kit/application.css
+++ b/app/assets/stylesheets/completion_kit/application.css
@@ -868,6 +868,12 @@ tr:hover .ck-chip--publish {
   color: var(--ck-muted);
 }
 
+.ck-field--info #refresh-status,
+.ck-field--warn #refresh-status,
+.ck-field--error #refresh-status {
+  color: var(--ck-muted);
+}
+
 .ck-field--info .ck-input {
   border-color: var(--ck-accent);
 }

--- a/app/controllers/completion_kit/api/v1/runs_controller.rb
+++ b/app/controllers/completion_kit/api/v1/runs_controller.rb
@@ -2,7 +2,7 @@ module CompletionKit
   module Api
     module V1
       class RunsController < BaseController
-        before_action :set_run, only: [:show, :update, :destroy, :generate]
+        before_action :set_run, only: [:show, :update, :destroy, :generate, :retry_failures]
 
         def index
           render json: Run.order(created_at: :desc)
@@ -42,6 +42,29 @@ module CompletionKit
           else
             render json: { errors: [@run.failure_summary || @run.errors.full_messages.to_sentence] }, status: :unprocessable_entity
           end
+        end
+
+        def retry_failures
+          scope = @run.responses.where(status: "failed")
+          scope = scope.where(id: params[:only]) if params[:only].present?
+
+          ActiveRecord::Base.transaction do
+            failed_response_ids = scope.pluck(:id)
+            CompletionKit::Review.where(response_id: failed_response_ids, status: "failed").update_all(
+              status: "pending", attempts: 0,
+              error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+              ai_score: nil, ai_feedback: nil
+            )
+            scope.update_all(
+              status: "pending", attempts: 0,
+              error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+              response_text: nil
+            )
+            @run.update!(status: "running")
+            failed_response_ids.each { |rid| CompletionKit::GenerateRowJob.perform_later(@run.id, rid) }
+          end
+
+          render json: @run.reload, status: :accepted
         end
 
         private

--- a/app/controllers/completion_kit/runs_controller.rb
+++ b/app/controllers/completion_kit/runs_controller.rb
@@ -1,6 +1,6 @@
 module CompletionKit
   class RunsController < ApplicationController
-    before_action :set_run, only: [:show, :edit, :update, :destroy, :generate, :suggest, :suggestion, :apply_suggestion]
+    before_action :set_run, only: [:show, :edit, :update, :destroy, :generate, :suggest, :suggestion, :apply_suggestion, :retry_failures]
     before_action :load_form_collections, only: [:new, :edit, :create, :update]
 
     def index
@@ -85,6 +85,32 @@ module CompletionKit
     def suggestion
       @suggestion = @run.suggestions.order(created_at: :desc).first
       return redirect_to run_path(@run), alert: "No suggestion available. Generate one first." unless @suggestion
+    end
+
+    def retry_failures
+      scope = @run.responses.where(status: "failed")
+      scope = scope.where(id: params[:only]) if params[:only].present?
+
+      ActiveRecord::Base.transaction do
+        failed_response_ids = scope.pluck(:id)
+        Review.where(response_id: failed_response_ids, status: "failed").update_all(
+          status: "pending",
+          attempts: 0,
+          error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+          ai_score: nil, ai_feedback: nil
+        )
+        scope.update_all(
+          status: "pending",
+          attempts: 0,
+          error_provider: nil, error_class: nil, error_status: nil, error_message: nil,
+          response_text: nil
+        )
+        @run.update!(status: "running")
+        failed_response_ids.each { |rid| GenerateRowJob.perform_later(@run.id, rid) }
+      end
+
+      @run.send(:broadcast_ui)
+      redirect_to run_path(@run)
     end
 
     def apply_suggestion

--- a/app/models/completion_kit/run.rb
+++ b/app/models/completion_kit/run.rb
@@ -137,13 +137,22 @@ module CompletionKit
     end
 
     def as_json(options = {})
+      snap = progress_snapshot
       {
         id: id, name: name, status: status, prompt_id: prompt_id,
         dataset_id: dataset_id, judge_model: judge_model, temperature: temperature,
         created_at: created_at, updated_at: updated_at,
         responses_count: responses.count, avg_score: avg_score,
-        progress_current: progress_current, progress_total: progress_total,
-        error_message: error_message, metric_ids: metric_ids
+        progress_current: snap[:generated_done],
+        progress_total: snap[:generated_total],
+        progress: {
+          generated: { done: snap[:generated_done], total: snap[:generated_total], failed: snap[:generated_failed] },
+          judged:    { done: snap[:judged_done],    total: snap[:judged_total],    failed: snap[:judged_failed] }
+        },
+        failed_response_ids: responses.where(status: "failed").pluck(:id),
+        failure_summary: failure_summary,
+        error_message: error_message,
+        metric_ids: metric_ids
       }
     end
 

--- a/app/services/completion_kit/worker_health.rb
+++ b/app/services/completion_kit/worker_health.rb
@@ -1,0 +1,10 @@
+module CompletionKit
+  class WorkerHealth
+    HEARTBEAT_THRESHOLD = 30.seconds
+
+    def self.healthy?
+      return true unless defined?(::SolidQueue::Process)
+      ::SolidQueue::Process.where("last_heartbeat_at > ?", HEARTBEAT_THRESHOLD.ago).exists?
+    end
+  end
+end

--- a/app/views/completion_kit/prompts/_form.html.erb
+++ b/app/views/completion_kit/prompts/_form.html.erb
@@ -38,9 +38,12 @@
       <% else %>
         <p class="ck-meta-copy">No models available. <%= link_to "Add a provider", provider_credentials_path, class: "ck-link" %> or click refresh after configuring a provider.</p>
       <% end %>
-      <% CompletionKit::ProviderCredential.find_each do |pc| %>
-        <%= turbo_stream_from "completion_kit_provider_#{pc.id}" %>
-      <% end %>
+      <div hidden data-refresh-progress-carriers>
+        <% CompletionKit::ProviderCredential.find_each do |pc| %>
+          <%= turbo_stream_from "completion_kit_provider_#{pc.id}" %>
+          <%= render "completion_kit/provider_credentials/discovery_status", provider_credential: pc, show_completed: false %>
+        <% end %>
+      </div>
       <p class="ck-field-hint" id="refresh-status" style="min-height: 1.2em; margin-top: -0.25rem; font-size: 0.75rem;">&nbsp;</p>
     </div>
 

--- a/app/views/completion_kit/runs/_form.html.erb
+++ b/app/views/completion_kit/runs/_form.html.erb
@@ -54,9 +54,12 @@
           <button type="button" class="ck-icon-btn" title="Refresh models" onclick="ckRefreshModels()"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path fill-rule="evenodd" d="M13.836 2.477a.75.75 0 0 1 .75.75v3.182a.75.75 0 0 1-.75.75h-3.182a.75.75 0 0 1 0-1.5h1.37l-.84-.841a4.5 4.5 0 0 0-7.08.681.75.75 0 0 1-1.264-.808 6 6 0 0 1 9.44-.908l.84.84V3.227a.75.75 0 0 1 .75-.75Zm-.911 7.5A.75.75 0 0 1 13.199 11a6 6 0 0 1-9.44.908l-.84-.84v1.68a.75.75 0 0 1-1.5 0V9.567a.75.75 0 0 1 .75-.75h3.182a.75.75 0 0 1 0 1.5h-1.37l.84.841a4.5 4.5 0 0 0 7.08-.681.75.75 0 0 1 1.024-.274Z" clip-rule="evenodd"/></svg></button>
         </div>
         <p class="ck-field-hint" id="judge-hint"></p>
-        <% CompletionKit::ProviderCredential.find_each do |pc| %>
-          <%= turbo_stream_from "completion_kit_provider_#{pc.id}" %>
-        <% end %>
+        <div hidden data-refresh-progress-carriers>
+          <% CompletionKit::ProviderCredential.find_each do |pc| %>
+            <%= turbo_stream_from "completion_kit_provider_#{pc.id}" %>
+            <%= render "completion_kit/provider_credentials/discovery_status", provider_credential: pc, show_completed: false %>
+          <% end %>
+        </div>
         <p class="ck-field-hint" id="refresh-status" style="min-height: 1.2em; margin-top: -0.25rem; font-size: 0.75rem;">&nbsp;</p>
       <% else %>
         <p class="ck-field-hint" style="color: var(--ck-warning);">No judge models available.&ensp;<%= link_to "Add a provider", provider_credentials_path, class: "ck-link" %></p>

--- a/app/views/completion_kit/runs/_response_row.html.erb
+++ b/app/views/completion_kit/runs/_response_row.html.erb
@@ -1,13 +1,29 @@
-<%= link_to run_response_path(run, response, sort: params[:sort]), class: "ck-response-row", id: "response_#{response.id}" do %>
+<%= link_to run_response_path(run, response, sort: params[:sort]), class: "ck-response-row ck-response-row--#{response.status}", id: "response_#{response.id}" do %>
   <span class="ck-response-row__index">#<%= index %></span>
-  <span class="ck-response-row__text"><%= truncate(response.response_text.to_s, length: 160) %></span>
+  <span class="ck-response-row__text">
+    <% if response.succeeded? %>
+      <%= truncate(response.response_text.to_s, length: 160) %>
+    <% elsif response.status == "failed" %>
+      <% err = response.error_payload %>
+      <span class="ck-response-row__error">
+        <%= err && err[:provider]&.titleize %><%= " #{err[:status]}" if err && err[:status] %> — <%= truncate(err && err[:message].to_s, length: 120) %>
+      </span>
+    <% end %>
+  </span>
   <span class="ck-response-row__score">
-    <% if response.reviewed? %>
-      <span class="ck-score"><span class="ck-score__star">★</span> <%= response.score %></span>
-    <% elsif run.status == "failed" %>
-      <span class="ck-chip">Failed</span>
-    <% elsif run.status == "running" %>
-      <span class="ck-chip">Running</span>
+    <% case response.status
+       when "succeeded" %>
+      <% if response.reviewed? %>
+        <span class="ck-score"><span class="ck-score__star">★</span> <%= response.score %></span>
+      <% elsif run.status == "running" %>
+        <span class="ck-chip">Judging</span>
+      <% end %>
+    <% when "pending" %>
+      <span class="ck-chip">Queued</span>
+    <% when "retrying" %>
+      <span class="ck-chip ck-chip--warning">Retrying <%= response.attempts %>/5</span>
+    <% when "failed" %>
+      <span class="ck-chip ck-chip--danger">Failed</span>
     <% end %>
   </span>
 <% end %>

--- a/app/views/completion_kit/runs/_response_row.html.erb
+++ b/app/views/completion_kit/runs/_response_row.html.erb
@@ -23,10 +23,9 @@
     <% when "retrying" %>
       <span class="ck-chip ck-chip--warning">Retrying <%= response.attempts %>/5</span>
     <% when "failed" %>
-      <%= button_to "Retry", retry_failures_run_path(run, only: response.id),
-            method: :post,
-            class: "ck-chip ck-chip--danger ck-chip--retry",
-            form_class: "inline-block" %>
+      <%= link_to "Retry", retry_failures_run_path(run, only: response.id),
+            data: { turbo_method: :post },
+            class: "ck-chip ck-chip--danger ck-chip--retry" %>
     <% end %>
   </span>
 <% end %>

--- a/app/views/completion_kit/runs/_response_row.html.erb
+++ b/app/views/completion_kit/runs/_response_row.html.erb
@@ -23,7 +23,10 @@
     <% when "retrying" %>
       <span class="ck-chip ck-chip--warning">Retrying <%= response.attempts %>/5</span>
     <% when "failed" %>
-      <span class="ck-chip ck-chip--danger">Failed</span>
+      <%= button_to "Retry", retry_failures_run_path(run, only: response.id),
+            method: :post,
+            class: "ck-chip ck-chip--danger ck-chip--retry",
+            form_class: "inline-block" %>
     <% end %>
   </span>
 <% end %>

--- a/app/views/completion_kit/runs/_status_header.html.erb
+++ b/app/views/completion_kit/runs/_status_header.html.erb
@@ -6,6 +6,12 @@
     </div>
   <% end %>
 
+  <% if run.status == "running" && !CompletionKit::WorkerHealth.healthy? %>
+    <div class="ck-flash ck-flash--alert">
+      No worker process is running. Generate and judge jobs are queued but nothing is processing them. Start <code>bin/jobs</code> (or your worker service) to resume.
+    </div>
+  <% end %>
+
   <section class="ck-page-header">
     <div>
       <p class="ck-kicker"><span class="<%= ck_run_dot(run) %>"></span> <%= ck_run_status_label(run) %></p>

--- a/app/views/completion_kit/runs/_status_header.html.erb
+++ b/app/views/completion_kit/runs/_status_header.html.erb
@@ -31,6 +31,14 @@
           <% end %>
         </div>
       <% end %>
+      <% failed_count = snap[:generated_failed] + snap[:judged_failed] %>
+      <% if failed_count > 0 %>
+        <%= button_to "Retry #{failed_count} failed #{"row".pluralize(failed_count)}",
+              retry_failures_run_path(run),
+              method: :post,
+              class: ck_button_classes(:light, variant: :outline),
+              form_class: "inline-block" %>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/completion_kit/runs/_status_header.html.erb
+++ b/app/views/completion_kit/runs/_status_header.html.erb
@@ -1,9 +1,11 @@
+<% snap = run.progress_snapshot %>
 <div id="run_status_header">
   <% if run.status == "failed" %>
     <div class="ck-flash ck-flash--alert">
-      <%= run.error_message.presence || "Run failed." %>
+      <%= run.failure_summary.presence || run.error_message.presence || "Run failed." %>
     </div>
   <% end %>
+
   <section class="ck-page-header">
     <div>
       <p class="ck-kicker"><span class="<%= ck_run_dot(run) %>"></span> <%= ck_run_status_label(run) %></p>
@@ -12,4 +14,23 @@
     </div>
     <%= render "completion_kit/runs/actions", run: run %>
   </section>
+
+  <% if run.status.in?(%w[running completed]) && snap[:generated_total] > 0 %>
+    <div class="ck-progress-block">
+      <div class="ck-progress-line">
+        Generated <%= snap[:generated_done] %>/<%= snap[:generated_total] %>
+        <% if snap[:generated_failed] > 0 %>
+          <span class="ck-progress-failed">(<%= snap[:generated_failed] %> failed)</span>
+        <% end %>
+      </div>
+      <% if snap[:judged_total] > 0 %>
+        <div class="ck-progress-line">
+          Judged <%= snap[:judged_done] %>/<%= snap[:judged_total] %>
+          <% if snap[:judged_failed] > 0 %>
+            <span class="ck-progress-failed">(<%= snap[:judged_failed] %> failed)</span>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/completion_kit/runs/show.html.erb
+++ b/app/views/completion_kit/runs/show.html.erb
@@ -52,7 +52,7 @@
   </div>
   <p class="ck-prompt-preview__text" id="prompt_text"><%= @run.prompt.template %></p>
   <% if @run.prompt.template.length > 200 %>
-    <button type="button" class="ck-link" id="prompt_toggle" aria-expanded="false" aria-controls="prompt_text" onclick="var t=document.getElementById('prompt_text');var l=this;var expanded=t.classList.toggle('ck-prompt-preview__text--expanded');l.textContent=expanded?'Show less':'Show more';l.setAttribute('aria-expanded',expanded?'true':'false')">Show more</button>
+    <button type="button" class="ck-disclosure-toggle" id="prompt_toggle" aria-expanded="false" aria-controls="prompt_text" onclick="var t=document.getElementById('prompt_text');var l=this;var expanded=t.classList.toggle('ck-prompt-preview__text--expanded');l.firstChild.textContent=expanded?'Show less':'Show more';l.setAttribute('aria-expanded',expanded?'true':'false')"><span>Show more</span></button>
   <% end %>
 </div>
 

--- a/app/views/layouts/completion_kit/application.html.erb
+++ b/app/views/layouts/completion_kit/application.html.erb
@@ -56,8 +56,7 @@ function ckRefreshModels() {
   ckRefreshing = true;
   var btn = document.querySelector('.ck-icon-btn[title="Refresh models"]');
   if (btn) btn.classList.add('ck-icon-btn--spinning');
-  var status = document.getElementById('refresh-status');
-  if (status) status.textContent = 'Refreshing models\u2026';
+  ckUpdateRefreshProgress();
   var csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute("content");
   fetch("/completion_kit/refresh_models", {
     method: "POST",
@@ -65,8 +64,35 @@ function ckRefreshModels() {
   });
 }
 
+function ckUpdateRefreshProgress() {
+  var status = document.getElementById('refresh-status');
+  if (!status) return;
+  var carriers = document.querySelectorAll('[data-refresh-progress-carriers] [id^="discovery_status_"]');
+  var totalCurrent = 0, totalTotal = 0, anyDiscovering = false;
+  carriers.forEach(function(node) {
+    if (!node.querySelector('.ck-discovery-bar')) return;
+    if (node.querySelector('.ck-discovery-bar--failed') || node.querySelector('.ck-discovery-bar--completed')) return;
+    anyDiscovering = true;
+    var match = node.textContent.match(/(\d+)\s*\/\s*(\d+)/);
+    if (match) {
+      totalCurrent += parseInt(match[1], 10);
+      totalTotal += parseInt(match[2], 10);
+    }
+  });
+  if (anyDiscovering || ckRefreshing) {
+    if (totalTotal > 0) {
+      status.textContent = 'Refreshing models\u2026 ' + totalCurrent + '/' + totalTotal;
+    } else {
+      status.textContent = 'Refreshing models\u2026';
+    }
+  }
+}
+
 document.addEventListener("turbo:before-stream-render", function(event) {
   var target = event.target.getAttribute("target");
+  if (target && target.indexOf("discovery_status_") === 0) {
+    requestAnimationFrame(ckUpdateRefreshProgress);
+  }
   if (target === "prompt_llm_model" || target === "run_judge_model") {
     ckRefreshing = false;
     var btn = document.querySelector('.ck-icon-btn[title="Refresh models"]');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ CompletionKit::Engine.routes.draw do
       get :suggestion
       post :suggest
       post :apply_suggestion
+      post :retry_failures
     end
     resources :responses, only: [:show]
   end
@@ -38,6 +39,7 @@ CompletionKit::Engine.routes.draw do
       resources :runs do
         member do
           post :generate
+          post :retry_failures
         end
         resources :responses, only: [:index, :show]
       end

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -11,6 +11,12 @@ FactoryBot.define do
       response_text { nil }
     end
 
+    trait :retrying do
+      status { "retrying" }
+      response_text { nil }
+      attempts { 2 }
+    end
+
     trait :failed do
       status { "failed" }
       response_text { nil }

--- a/spec/models/completion_kit/json_serialization_spec.rb
+++ b/spec/models/completion_kit/json_serialization_spec.rb
@@ -89,3 +89,41 @@ RSpec.describe "JSON serialization" do
     end
   end
 end
+
+RSpec.describe "Run#as_json includes progress object and failed_response_ids" do
+  before do
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_ui)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_progress)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_status_header)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_actions)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_sort_toolbar)
+  end
+
+  let(:run) { create(:completion_kit_run, progress_total: 2) }
+
+  it "includes a progress hash with generated and judged sub-objects" do
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "a")
+    create(:completion_kit_response, :failed, run: run)
+
+    payload = run.as_json
+    expect(payload[:progress][:generated]).to include(done: 1, total: 2, failed: 1)
+    expect(payload[:progress][:judged]).to include(done: 0, total: 0, failed: 0)
+    expect(payload[:failed_response_ids]).to be_an(Array)
+    expect(payload[:failed_response_ids].size).to eq(1)
+  end
+
+  it "preserves legacy progress_current and progress_total fields mapped to generated counters" do
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "a")
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "b")
+    payload = run.as_json
+    expect(payload).to have_key(:progress_current)
+    expect(payload).to have_key(:progress_total)
+    expect(payload[:progress_current]).to eq(2)
+    expect(payload[:progress_total]).to eq(2)
+  end
+
+  it "includes failure_summary key" do
+    payload = run.as_json
+    expect(payload).to have_key(:failure_summary)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -172,6 +172,17 @@ ActiveRecord::Schema.define do
     t.datetime :applied_at
     t.timestamps
   end
+
+  create_table :solid_queue_processes, force: true do |t|
+    t.string :kind, null: false
+    t.datetime :last_heartbeat_at, null: false
+    t.bigint :supervisor_id
+    t.integer :pid, null: false
+    t.string :hostname
+    t.text :metadata
+    t.datetime :created_at, null: false
+    t.string :name, null: false
+  end
 end
 
 FactoryBot.definition_file_paths = [File.expand_path("factories", __dir__)]

--- a/spec/requests/completion_kit/api/v1/runs_spec.rb
+++ b/spec/requests/completion_kit/api/v1/runs_spec.rb
@@ -95,6 +95,38 @@ RSpec.describe "API V1 Runs", type: :request do
     end
   end
 
+  describe "POST /api/v1/runs/:id/retry_failures" do
+    before { allow(CompletionKit::GenerateRowJob).to receive(:perform_later) }
+
+    it "resets failed responses and returns 202" do
+      run = create(:completion_kit_run, status: "completed")
+      failed = create(:completion_kit_response, :failed, run: run, row_index: 0)
+
+      post "/completion_kit/api/v1/runs/#{run.id}/retry_failures", headers: headers
+
+      expect(response).to have_http_status(:accepted)
+      expect(failed.reload.status).to eq("pending")
+      expect(run.reload.status).to eq("running")
+      expect(CompletionKit::GenerateRowJob).to have_received(:perform_later).with(run.id, failed.id)
+    end
+
+    it "scopes to a single response when only param is supplied" do
+      run = create(:completion_kit_run, status: "completed")
+      failed_a = create(:completion_kit_response, :failed, run: run, row_index: 0)
+      failed_b = create(:completion_kit_response, :failed, run: run, row_index: 1)
+
+      post "/completion_kit/api/v1/runs/#{run.id}/retry_failures",
+        params: {only: failed_a.id}.to_json,
+        headers: headers
+
+      expect(response).to have_http_status(:accepted)
+      expect(failed_a.reload.status).to eq("pending")
+      expect(failed_b.reload.status).to eq("failed")
+      expect(CompletionKit::GenerateRowJob).to have_received(:perform_later).with(run.id, failed_a.id)
+      expect(CompletionKit::GenerateRowJob).not_to have_received(:perform_later).with(run.id, failed_b.id)
+    end
+  end
+
   describe "POST /api/v1/runs/:id/generate" do
     it "calls start! and returns 202 on success" do
       run = create(:completion_kit_run)

--- a/spec/requests/completion_kit/runs_retry_failures_spec.rb
+++ b/spec/requests/completion_kit/runs_retry_failures_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "POST /completion_kit/runs/:id/retry_failures", type: :request do
+  let(:run) { create(:completion_kit_run, status: "completed") }
+
+  before do
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_ui)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_progress)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_status_header)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_actions)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_sort_toolbar)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_clear_responses)
+    allow(CompletionKit::GenerateRowJob).to receive(:perform_later)
+  end
+
+  it "resets failed responses to pending and re-enqueues their jobs" do
+    failed = create(:completion_kit_response, :failed, run: run, row_index: 0)
+    succeeded = create(:completion_kit_response, run: run, status: "succeeded", row_index: 1, response_text: "ok")
+
+    post "/completion_kit/runs/#{run.id}/retry_failures"
+
+    failed.reload
+    succeeded.reload
+
+    expect(failed.status).to eq("pending")
+    expect(failed.error_class).to be_nil
+    expect(failed.attempts).to eq(0)
+    expect(succeeded.status).to eq("succeeded")
+    expect(run.reload.status).to eq("running")
+    expect(CompletionKit::GenerateRowJob).to have_received(:perform_later).with(run.id, failed.id)
+    expect(CompletionKit::GenerateRowJob).not_to have_received(:perform_later).with(run.id, succeeded.id)
+  end
+
+  it "scopes to a single response when only param is supplied" do
+    failed_a = create(:completion_kit_response, :failed, run: run, row_index: 0)
+    failed_b = create(:completion_kit_response, :failed, run: run, row_index: 1)
+
+    post "/completion_kit/runs/#{run.id}/retry_failures", params: { only: failed_a.id }
+
+    expect(failed_a.reload.status).to eq("pending")
+    expect(failed_b.reload.status).to eq("failed")
+    expect(CompletionKit::GenerateRowJob).to have_received(:perform_later).with(run.id, failed_a.id)
+    expect(CompletionKit::GenerateRowJob).not_to have_received(:perform_later).with(run.id, failed_b.id)
+  end
+end

--- a/spec/requests/completion_kit/runs_spec.rb
+++ b/spec/requests/completion_kit/runs_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "CompletionKit runs", type: :request do
     expect(response).to have_http_status(:ok)
     expect(response.body).to include("Queued")
     expect(response.body).to include("Retrying")
-    expect(response.body).to include("Failed")
+    expect(response.body).to include("ck-chip--retry")
   end
 
   it "renders a failed response row with provider error details" do

--- a/spec/requests/completion_kit/runs_spec.rb
+++ b/spec/requests/completion_kit/runs_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe "CompletionKit runs", type: :request do
     expect(response).to have_http_status(:ok)
   end
 
+  it "renders the show page with pending, retrying, and failed response rows" do
+    run = create(:completion_kit_run, prompt: prompt, status: "running")
+    create(:completion_kit_response, :pending, run: run)
+    create(:completion_kit_response, :retrying, run: run)
+    create(:completion_kit_response, :failed, run: run)
+
+    get "#{base_path}/#{run.id}"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Queued")
+    expect(response.body).to include("Retrying")
+    expect(response.body).to include("Failed")
+  end
+
+  it "renders a failed response row with provider error details" do
+    run = create(:completion_kit_run, prompt: prompt)
+    create(:completion_kit_response, :failed, run: run, error_provider: "openai", error_status: 429, error_message: "Rate limit exceeded")
+
+    get "#{base_path}/#{run.id}"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Openai")
+    expect(response.body).to include("429")
+    expect(response.body).to include("Rate limit exceeded")
+  end
+
+  it "renders succeeded response with judging chip when run is still running" do
+    run = create(:completion_kit_run, prompt: prompt, status: "running")
+    create(:completion_kit_response, run: run, status: "succeeded", response_text: "Output text")
+
+    get "#{base_path}/#{run.id}"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Judging")
+  end
+
   it "creates a run with valid params" do
     dataset = create(:completion_kit_dataset)
 

--- a/spec/services/completion_kit/worker_health_spec.rb
+++ b/spec/services/completion_kit/worker_health_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe CompletionKit::WorkerHealth do
+  describe ".healthy?" do
+    context "when SolidQueue::Process is not defined" do
+      around do |example|
+        if defined?(::SolidQueue::Process)
+          original = ::SolidQueue.const_get(:Process)
+          ::SolidQueue.send(:remove_const, :Process)
+          example.run
+          ::SolidQueue.const_set(:Process, original)
+        else
+          example.run
+        end
+      end
+
+      it "returns true (other adapters in use; treat as healthy)" do
+        expect(described_class.healthy?).to eq(true)
+      end
+    end
+
+    context "when SolidQueue::Process is defined" do
+      let(:fake_process_class) do
+        Class.new do
+          class << self
+            attr_accessor :exists_result
+            def where(*)
+              relation = Object.new
+              relation.define_singleton_method(:exists?) { Class.singleton_class.send(:attr_accessor, :exists_result) || self }
+              result = exists_result
+              relation.define_singleton_method(:exists?) { result }
+              relation
+            end
+          end
+        end
+      end
+
+      before do
+        stub_const("SolidQueue", Module.new) unless defined?(::SolidQueue)
+        stub_const("SolidQueue::Process", fake_process_class)
+      end
+
+      it "returns true when at least one process has heartbeat'd within threshold" do
+        fake_process_class.exists_result = true
+        expect(described_class.healthy?).to eq(true)
+      end
+
+      it "returns false when no process has heartbeat'd within threshold" do
+        fake_process_class.exists_result = false
+        expect(described_class.healthy?).to eq(false)
+      end
+    end
+  end
+end

--- a/standalone/config/routes.rb
+++ b/standalone/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   post "login", to: "sessions#create"
   delete "logout", to: "sessions#destroy"
 
+  constraints JobsDashboardConstraint do
+    mount MissionControl::Jobs::Engine, at: "/jobs"
+  end
+
   root to: "home#index"
   mount CompletionKit::Engine => "/completion_kit"
 end

--- a/standalone/lib/jobs_dashboard_constraint.rb
+++ b/standalone/lib/jobs_dashboard_constraint.rb
@@ -1,0 +1,7 @@
+class JobsDashboardConstraint
+  def self.matches?(request)
+    cfg = CompletionKit.config
+    return true unless cfg.username && cfg.password
+    request.session[:authenticated]
+  end
+end


### PR DESCRIPTION
## Summary

UI + JSON API surface for the new run lifecycle. Status header consumes `Run#progress_snapshot` to show split generation/judging counters. Response rows branch on per-row status and surface provider error context inline. New retry-failed-rows action on web + API. JSON API extended with `progress` object.

This is **PR 3 of 3** in a stacked series. Stacks on top of `prompt-run-robustness/phase-2-jobs` (PR 15). Spec: `docs/superpowers/specs/2026-05-01-prompt-run-robustness-design.md`.

## What's in this PR

- **`_status_header.html.erb` rewritten** to consume `Run#progress_snapshot` and render a split counter block:
  ```
  Generated 47/100 (3 failed)
  Judged    38/200 (1 failed)
  [Retry 4 failed rows]
  ```
- **`_response_row.html.erb` rewritten** to branch on `response.status`. Failed rows render provider name + status + truncated error message inline (`Failed: OpenAI 429 — Rate limit exceeded`) plus a per-row Retry link. Retrying rows show `Retrying N/5`.
- **`retry_failures` action + route** on web (`POST /runs/:id/retry_failures`) and API v1 (`POST /api/v1/runs/:id/retry_failures`). Resets failed Responses (and dependent Reviews) to pending, clears error fields, sets attempts to 0, transitions run back to `running`, re-enqueues `GenerateRowJob` for each reset response. `?only=<id>` scopes to a single response.
- **`Run#as_json` extended** with `progress` object (`generated`/`judged` sub-objects, each with `done/total/failed`), `failed_response_ids`, and `failure_summary`. Legacy `progress_current` and `progress_total` keys preserved for backward compat (mapped to generation counters).
- **Mission Control dashboard mounted** at `/jobs` in the standalone, gated by the existing session-auth pattern.
- **Worker-health banner.** New `CompletionKit::WorkerHealth.healthy?` checks whether any Solid Queue process has heartbeat'd in the last 30s. The status header on `running` runs renders an alert banner when no worker is alive ("No worker process is running. Generate and judge jobs are queued but nothing is processing them. Start `bin/jobs` (or your worker service) to resume."). Adapter-agnostic — returns `true` when `SolidQueue::Process` isn't loaded so apps using Sidekiq/etc. don't see false positives.
- **One review fix:** `_response_row.html.erb` Retry button switched from `button_to` (which produces `<form>` inside `<a>` — invalid HTML) to `link_to ... data: { turbo_method: :post }`.

## Test plan

- [ ] CI green: 542 examples, 0 failures, 100% line + branch coverage
- [ ] Visit a run with mixed succeeded/failed responses; confirm header shows split counters and "Retry N failed rows" button
- [ ] Click a per-row Retry on a failed response; verify only that row resets and re-runs
- [ ] `GET /api/v1/runs/:id` returns the new `progress` object with `generated`/`judged` sub-objects
- [ ] `POST /api/v1/runs/:id/retry_failures` returns 202 and re-enqueues failed rows
- [ ] `/jobs` dashboard reachable behind login

## Notes for reviewer

- 6 commits, ~XXX/-XXX. The 5 task commits (status header rewrite, response row rewrite, retry_failures, as_json, dashboard mount) plus the post-review HTML fix.
- Per-row Retry is technically a nested `<a>` inside `<a>` (still HTML-invalid but Turbo's stopPropagation handles it cleanly). A follow-up could restructure the row to side-by-side elements; flagged as Minor in the final review.

## Follow-ups (NOT in this PR — for after rollout)

- **`Run#start!` `responses.destroy_all` is unconditional.** Web controller guards via "create new run if responses exist" but API doesn't. A scripted client calling `POST /api/v1/runs/:id/generate` twice loses succeeded rows. Worth gating `start!` on `status == "pending"`.
- **Job-test `@ivar || arguments.last` defensive fallbacks** exist because some specs stub `perform` directly. Cleaner: stub the dependency that raises.
- **`JudgeReviewJob.concurrency_key` does a `Response.find_by` per enqueue** (~300 queries for a 100-row × 3-metric run). Pass `run_id` as a 3rd job arg to avoid.
- **Extract `HasErrorContext` concern** shared between Response and Review; consider moving broadcasts into model `after_save_commit` callbacks so jobs don't `send(:broadcast_response_update)` on a private model method.