### PR TITLE
env example: generate encryption keys with openssl, no Rails toolchain

### DIFF
--- a/standalone/.env.example
+++ b/standalone/.env.example
@@ -4,8 +4,12 @@ COMPLETION_KIT_PASSWORD=
 
 # Encryption keys for stored provider API keys. In production these are REQUIRED;
 # the app refuses to boot without them. In development, a literal fallback is used
-# so `bin/rails s` works on a fresh clone. Generate real values with:
-#   bin/rails db:encryption:init
+# so `bin/rails s` works on a fresh clone.
+#
+# Each value is just a random string. Generate one per key, no Rails install
+# needed:
+#   openssl rand -hex 32
+# (or, with the Rails toolchain on hand: bin/rails db:encryption:init)
 COMPLETION_KIT_ENCRYPTION_PRIMARY_KEY=
 COMPLETION_KIT_ENCRYPTION_DETERMINISTIC_KEY=
 COMPLETION_KIT_ENCRYPTION_KEY_DERIVATION_SALT=


### PR DESCRIPTION
Closes #39.

## What

`standalone/.env.example` told people to generate the three `COMPLETION_KIT_ENCRYPTION_*` keys with `bin/rails db:encryption:init`, which means installing Ruby + Rails on the host just to produce three random strings — friction for a Docker self-host.

The comment now points at `openssl rand -hex 32` (no Rails install needed), keeping `bin/rails db:encryption:init` as a secondary option for anyone who already has the toolchain.

## Scope

The main `README.md` Docker section already documents `openssl rand` for both the encryption keys and `SECRET_KEY_BASE` (done in an earlier commit). `SECRET_KEY_BASE` is not added to `.env.example` because it is a production/Docker variable, not a development one — the dev `.env.example` has no use for it.

No code change — purely the env template comment.