### PR TITLE
Fix model-discovery polling for hosts that remount the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Live model-discovery polling now works when the engine is mounted under a non-default path.** The polling request added in 0.12.1 hardcoded the engine's standalone mount (`/completion_kit/provider_credentials/statuses`), so a host that remounts the engine elsewhere (for example under a per-tenant URL scope) polled a path that 404s, and the providers page never updated. The poll URL is now rendered server-side from the `statuses` route helper into a `data-ck-statuses-url` attribute, so it follows whatever mount the host uses. The one remaining unguarded broadcast, `broadcast_model_dropdowns`, is now wrapped too, so a worker render failure logs and continues instead of aborting discovery completion.
+
 ## [0.12.1] - 2026-06-08
 
 ### Fixed

--- a/app/assets/javascripts/completion_kit/application.js
+++ b/app/assets/javascripts/completion_kit/application.js
@@ -131,8 +131,15 @@ function ckDiscoveringInDom() {
   return !!document.querySelector('[id^="discovery_status_"] .ck-discovery-bar:not(.ck-discovery-bar--failed):not(.ck-discovery-bar--completed)');
 }
 
+function ckStatusesUrl() {
+  var el = document.querySelector("[data-ck-statuses-url]");
+  return el ? el.getAttribute("data-ck-statuses-url") : null;
+}
+
 function ckPollDiscoveryOnce() {
-  fetch("/completion_kit/provider_credentials/statuses", { headers: { "Accept": "text/vnd.turbo-stream.html" } })
+  var url = ckStatusesUrl();
+  if (!url) return;
+  fetch(url, { headers: { "Accept": "text/vnd.turbo-stream.html" } })
     .then(function(r) { return r.ok ? r.text() : null; })
     .then(function(html) {
       if (html && window.Turbo && window.Turbo.renderStreamMessage) window.Turbo.renderStreamMessage(html);
@@ -142,6 +149,7 @@ function ckPollDiscoveryOnce() {
 
 function ckStartDiscoveryPolling(graceMs) {
   if (!document.querySelector('[id^="discovery_status_"]')) return;
+  if (!ckStatusesUrl()) return;
   ckDiscoveryPollUntil = Date.now() + (graceMs || 0);
   if (ckDiscoveryPollTimer) return;
   ckPollDiscoveryOnce();

--- a/app/models/completion_kit/provider_credential.rb
+++ b/app/models/completion_kit/provider_credential.rb
@@ -114,22 +114,24 @@ module CompletionKit
     end
 
     def broadcast_model_dropdowns
-      helper = ApplicationController.helpers
-      gen_html = helper.ck_model_options_html(:generation)
-      judge_html = '<option value="">None</option>' + helper.ck_model_options_html(:judging)
+      safely_broadcast do
+        helper = ApplicationController.helpers
+        gen_html = helper.ck_model_options_html(:generation)
+        judge_html = '<option value="">None</option>' + helper.ck_model_options_html(:judging)
 
-      Turbo::StreamsChannel.broadcast_action_to(
-        "completion_kit_provider_#{id}",
-        action: :replace,
-        target: "prompt_llm_model",
-        html: "<select name=\"prompt[llm_model]\" id=\"prompt_llm_model\" class=\"ck-input\">#{gen_html}</select>"
-      )
-      Turbo::StreamsChannel.broadcast_action_to(
-        "completion_kit_provider_#{id}",
-        action: :replace,
-        target: "run_judge_model",
-        html: "<select name=\"run[judge_model]\" id=\"run_judge_model\" class=\"ck-input\">#{judge_html}</select>"
-      )
+        Turbo::StreamsChannel.broadcast_action_to(
+          "completion_kit_provider_#{id}",
+          action: :replace,
+          target: "prompt_llm_model",
+          html: "<select name=\"prompt[llm_model]\" id=\"prompt_llm_model\" class=\"ck-input\">#{gen_html}</select>"
+        )
+        Turbo::StreamsChannel.broadcast_action_to(
+          "completion_kit_provider_#{id}",
+          action: :replace,
+          target: "run_judge_model",
+          html: "<select name=\"run[judge_model]\" id=\"run_judge_model\" class=\"ck-input\">#{judge_html}</select>"
+        )
+      end
     end
 
     def render_partial(partial, locals)

--- a/app/views/completion_kit/provider_credentials/_form.html.erb
+++ b/app/views/completion_kit/provider_credentials/_form.html.erb
@@ -38,5 +38,7 @@
 
 <% if provider_credential.persisted? %>
   <%= turbo_stream_from "completion_kit_provider_#{provider_credential.id}" %>
-  <%= render "models_card", provider_credential: provider_credential %>
+  <div data-ck-statuses-url="<%= statuses_provider_credentials_path %>">
+    <%= render "models_card", provider_credential: provider_credential %>
+  </div>
 <% end %>

--- a/app/views/completion_kit/provider_credentials/index.html.erb
+++ b/app/views/completion_kit/provider_credentials/index.html.erb
@@ -16,7 +16,7 @@
 
 <% if @provider_credentials.any? %>
   <% default_endpoints = {"openai" => "https://api.openai.com", "anthropic" => "https://api.anthropic.com"} %>
-  <div class="ck-provider-list">
+  <div class="ck-provider-list" data-ck-statuses-url="<%= statuses_provider_credentials_path %>">
     <% @provider_credentials.each do |provider_credential| %>
       <% masked_key = provider_credential.api_key.present? ? "#{provider_credential.api_key[0..6]}#{'•' * 12}#{provider_credential.api_key[-4..]}" : "—" %>
       <a href="<%= edit_provider_credential_path(provider_credential) %>" class="ck-provider-card">

--- a/spec/models/completion_kit/provider_credential_spec.rb
+++ b/spec/models/completion_kit/provider_credential_spec.rb
@@ -182,6 +182,27 @@ RSpec.describe CompletionKit::ProviderCredential, type: :model do
     end
   end
 
+  describe "#broadcast_model_dropdowns when broadcasting fails in a worker" do
+    it "logs and swallows the error so discovery completion is not aborted" do
+      credential = create(:completion_kit_provider_credential, provider: "openai", api_key: "sk-test")
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to).and_raise(StandardError, "dropdown boom")
+
+      expect(Rails.logger).to receive(:error).with(/discovery broadcast render failed.*dropdown boom/).at_least(:once)
+      expect { credential.send(:broadcast_model_dropdowns) }.not_to raise_error
+    end
+  end
+
+  describe "#broadcast_discovery_complete when a broadcast fails in a worker" do
+    it "does not raise so the persisted completed status survives" do
+      credential = create(:completion_kit_provider_credential, provider: "openai", api_key: "sk-test")
+      allow(credential).to receive(:render_partial).and_raise(StandardError, "render boom")
+      allow(Turbo::StreamsChannel).to receive(:broadcast_action_to).and_raise(StandardError, "dropdown boom")
+      allow(Rails.logger).to receive(:error)
+
+      expect { credential.broadcast_discovery_complete }.not_to raise_error
+    end
+  end
+
   describe "api_endpoint SSRF validation" do
     def cred(endpoint)
       build(:completion_kit_provider_credential, provider: "ollama", api_endpoint: endpoint)

--- a/spec/requests/completion_kit/provider_credentials_spec.rb
+++ b/spec/requests/completion_kit/provider_credentials_spec.rb
@@ -85,4 +85,14 @@ RSpec.describe "CompletionKit provider credentials", type: :request do
     expect(response.body).to include("Checking models")
     expect(response.body).to include("2/5")
   end
+
+  it "exposes the statuses polling url so the client polls the engine's actual mount path" do
+    credential = create(:completion_kit_provider_credential, provider: "openai", api_key: "sk-test")
+
+    get base_path
+    expect(response.body).to include(%(data-ck-statuses-url="#{base_path}/statuses"))
+
+    get "#{base_path}/#{credential.id}/edit"
+    expect(response.body).to include(%(data-ck-statuses-url="#{base_path}/statuses"))
+  end
 end


### PR DESCRIPTION
## Problem

0.12.1 fixed the stuck "Looking up models…" card (#59) by polling a new `statuses` endpoint from the browser instead of relying on worker Turbo broadcasts. But the poll URL was hardcoded to the engine's **standalone** mount:

```js
fetch("/completion_kit/provider_credentials/statuses", ...)
```

Any host that remounts the engine under a different path breaks. The hosted, multi-tenant deployment mounts it under a per-tenant scope (`/orgs/:org_slug/...`), so the poll hits a path that does not exist, 404s, fails silently (`.catch(function(){})`), and the providers **index** card never updates, exactly the original symptom. The detail page is fine because it server-renders from the persisted `discovery_status`.

## Fix

- Render the statuses path from its route helper (`statuses_provider_credentials_path`) into a `data-ck-statuses-url` attribute on the index list and the provider edit page. The client reads that attribute instead of a literal, so polling follows whatever mount the host uses (correct in both standalone and any remounted host). The attribute lives on page-level containers, not on the broadcast partials, so the broadcast render path is unchanged.
- Wrap `broadcast_model_dropdowns` in `safely_broadcast`. It was the one broadcast still able to raise out of `broadcast_discovery_complete` in a worker; an unhandled raise there hits the job's `rescue_from(StandardError)` and flips a finished discovery to `failed`. Now it logs and continues like the other broadcasts.

## Tests

- Request spec: index and edit expose `data-ck-statuses-url` equal to the route-helper path (would have caught the hardcoded literal).
- Model specs: `broadcast_model_dropdowns` logs and swallows on broadcast failure; `broadcast_discovery_complete` does not raise when a worker broadcast fails.
- Full suite: 1162 examples, 0 failures, 100% line + branch coverage.

Refs #59 (completes it for hosts that remount the engine). No version bump in this PR.
