### PR TITLE
Add runs-index host integration hooks (scope + footer slot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Host integration hooks for the runs list (`runs_index_scope`, `runs_index_footer_partial`).** A host app can now filter the runs index and append its own footer to the list through supported config seams, instead of reaching into the controller or overriding the view. `config.runs_index_scope` takes a callable evaluated against the index relation, so a multi-tenant host can apply something like run-history retention to the list only, rather than a global `default_scope` that would null `Run` associations everywhere else. `config.runs_index_footer_partial` names a partial rendered below the list, for an "older runs are hidden, upgrade to see them" notice. Both default to off, so standalone behaviour is unchanged.
+
 ## [0.16.2] - 2026-06-12
 
 ### Changed

--- a/app/controllers/completion_kit/runs_controller.rb
+++ b/app/controllers/completion_kit/runs_controller.rb
@@ -5,7 +5,10 @@ module CompletionKit
     before_action :load_form_collections, only: [:new, :edit, :create, :update]
 
     def index
-      @runs = apply_tag_filter(Run.includes(:prompt, :dataset, :tags, responses: :reviews).order(created_at: :desc))
+      scope = Run.includes(:prompt, :dataset, :tags, responses: :reviews).order(created_at: :desc)
+      index_scope = CompletionKit.config.runs_index_scope
+      scope = scope.instance_exec(&index_scope) if index_scope
+      @runs = apply_tag_filter(scope)
     end
 
     def show

--- a/app/views/completion_kit/runs/index.html.erb
+++ b/app/views/completion_kit/runs/index.html.erb
@@ -22,3 +22,7 @@
 <% else %>
   <div class="ck-empty">No runs yet.&ensp;<%= link_to "Create your first run →", new_run_path, class: "ck-link" %></div>
 <% end %>
+
+<% if CompletionKit.config.runs_index_footer_partial %>
+  <%= render CompletionKit.config.runs_index_footer_partial %>
+<% end %>

--- a/lib/completion_kit.rb
+++ b/lib/completion_kit.rb
@@ -10,6 +10,7 @@ module CompletionKit
     attr_accessor :username, :password, :auth_strategy, :api_token
     attr_accessor :tenant_scope, :tenant_scope_columns
     attr_accessor :api_reference_authentication_partial
+    attr_accessor :runs_index_scope, :runs_index_footer_partial
     attr_accessor :api_rate_limit, :web_rate_limit
     attr_accessor :allow_loopback_endpoints
     attr_accessor :judge_agreement_enabled

--- a/spec/dummy/app/views/spec_host/_runs_footer.html.erb
+++ b/spec/dummy/app/views/spec_host/_runs_footer.html.erb
@@ -1,0 +1,1 @@
+<div class="spec-host-runs-footer">spec-host-runs-footer</div>

--- a/spec/requests/completion_kit/runs_spec.rb
+++ b/spec/requests/completion_kit/runs_spec.rb
@@ -22,6 +22,30 @@ RSpec.describe "CompletionKit runs", type: :request do
     expect(response.body).to include("Run A")
   end
 
+  it "filters the index list through a host-configured runs_index_scope" do
+    create(:completion_kit_run, prompt: prompt, name: "Recent Run")
+    create(:completion_kit_run, prompt: prompt, name: "Old Run", created_at: 90.days.ago)
+    CompletionKit.config.runs_index_scope = -> { where(created_at: 30.days.ago..) }
+
+    get base_path
+
+    expect(response.body).to include("Recent Run")
+    expect(response.body).not_to include("Old Run")
+  ensure
+    CompletionKit.config.runs_index_scope = nil
+  end
+
+  it "renders a host-configured runs_index_footer_partial below the list" do
+    create(:completion_kit_run, prompt: prompt, name: "Run A")
+    CompletionKit.config.runs_index_footer_partial = "spec_host/runs_footer"
+
+    get base_path
+
+    expect(response.body).to include("spec-host-runs-footer")
+  ensure
+    CompletionKit.config.runs_index_footer_partial = nil
+  end
+
   it "renders the new-run form with no prompt preselected" do
     get "#{base_path}/new"
     expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## What

Two opt-in config seams so a host app can participate in the runs index without reaching into the controller or overriding the view:

- **`config.runs_index_scope`** — a callable evaluated against the index relation. A multi-tenant host can apply list-level filters (e.g. run-history retention) to the runs list only.
- **`config.runs_index_footer_partial`** — names a partial rendered below the runs list, for an "older runs are hidden, upgrade to see them" notice.

Both default to off, so standalone behaviour is unchanged.

## Why

In completion-kit-cloud, run-history retention was implemented as a global `default_scope` on `Run`. That hid old runs from the list as intended, but it also nulled `response.run` and every other `Run` association, 500ing any page that traversed them (the metric trust panel, the dashboard worst-metric card, and several jobs).

Cloud's root-cause fix removed the `default_scope` and now filters the list explicitly, but it currently does so by prepending the engine's private `RunsController#index`, which only works because `index` happens to hand back a still-chainable `@runs`. These hooks make that a supported contract, and give cloud a real slot for the "N runs hidden" footer instead of overriding the whole index view.

## Tests

`spec/requests/completion_kit/runs_spec.rb` covers both hooks (scope filters the list; footer partial renders). Full suite green, 100% line + branch coverage.