### PR TITLE
Grade blank cells in score-only runs instead of crashing start!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A blank cell in the graded column no longer crashes a score-only run.** `start!` raised a `RecordInvalid` mid-transaction (the response presence validation rejected the empty string), leaving the run stuck in `pending` with no responses, no failure summary, and a 500 at the API layer. A blank cell is now a legitimate graded value: the row is created and the check fails it against the row's expected value with a clear detail. Any other row that cannot be built now fails the run with a row-scoped `failure_summary` instead of raising.
+
+### Changed
+- Reworded the `runs_generate` MCP tool description to say it starts every run, including score-only runs; the old wording ("using its prompt and dataset") suggested it did not apply to prompt-less runs, so they were left sitting in `pending`.
+
 ## [0.23.0] - 2026-07-04
 
 ### Removed

--- a/app/models/completion_kit/response.rb
+++ b/app/models/completion_kit/response.rb
@@ -59,7 +59,7 @@ module CompletionKit
     private
 
     def requires_response_text?
-      succeeded? && !run&.judge_only_input_data_checks?
+      succeeded? && !run&.judge_only?
     end
 
     def broadcast_row_update

--- a/app/models/completion_kit/run.rb
+++ b/app/models/completion_kit/run.rb
@@ -198,40 +198,48 @@ module CompletionKit
         end
       end
 
-      transaction do
-        responses.destroy_all
-        update!(
-          status: "running",
-          progress_current: 0,
-          progress_total: rows.length,
-          failure_summary: nil,
-          error_message: nil
-        )
-        rows.each_with_index do |row, index|
-          input = row.empty? ? nil : row.to_json
-          attrs = {
-            status: "pending",
-            row_index: index,
-            input_data: input,
-            expected_output: row["expected_output"]
-          }
-          if judge_only?
-            attrs[:status] = "succeeded"
-            column = output_column.presence || "actual_output"
-            attrs[:response_text] = row[column].to_s if dataset && dataset.headers.include?(column)
+      failed_row = nil
+      begin
+        transaction do
+          responses.destroy_all
+          update!(
+            status: "running",
+            progress_current: 0,
+            progress_total: rows.length,
+            failure_summary: nil,
+            error_message: nil
+          )
+          rows.each_with_index do |row, index|
+            failed_row = index
+            input = row.empty? ? nil : row.to_json
+            attrs = {
+              status: "pending",
+              row_index: index,
+              input_data: input,
+              expected_output: row["expected_output"]
+            }
+            if judge_only?
+              attrs[:status] = "succeeded"
+              column = output_column.presence || "actual_output"
+              attrs[:response_text] = row[column].to_s if dataset && dataset.headers.include?(column)
+            end
+
+            response = responses.create!(attrs)
+
+            if judge_only?
+              llm_metrics.each { |m| JudgeReviewJob.perform_later(response.id, m.id, id) } if llm_judge_configured?
+              check_metrics.each { |m| CheckReviewJob.perform_later(response.id, m.id, id) }
+            else
+              GenerateRowJob.perform_later(id, response.id)
+            end
           end
 
-          response = responses.create!(attrs)
-
-          if judge_only?
-            llm_metrics.each { |m| JudgeReviewJob.perform_later(response.id, m.id, id) } if llm_judge_configured?
-            check_metrics.each { |m| CheckReviewJob.perform_later(response.id, m.id, id) }
-          else
-            GenerateRowJob.perform_later(id, response.id)
-          end
+          RunCompletionCheckJob.perform_later(id) if judge_only?
         end
-
-        RunCompletionCheckJob.perform_later(id) if judge_only?
+      rescue ActiveRecord::RecordInvalid => e
+        reload
+        detail = e.record.errors.full_messages.to_sentence
+        return fail_with_summary!(failed_row ? "Row #{failed_row + 1}: #{detail}" : detail)
       end
 
       safely_broadcast do

--- a/app/services/completion_kit/mcp_tools/runs.rb
+++ b/app/services/completion_kit/mcp_tools/runs.rb
@@ -50,7 +50,7 @@ module CompletionKit
           handler: :delete
         },
         "runs_generate" => {
-          description: "Generate responses for a run using its prompt and dataset",
+          description: "Start a run. Required for every run, including score-only runs (no prompt): generates responses with the prompt when there is one, otherwise copies the graded dataset column and grades it.",
           inputSchema: {type: "object", properties: {id: {type: "integer"}}, required: ["id"]},
           handler: :generate
         }

--- a/spec/integration/completion_kit/score_only_expected_spec.rb
+++ b/spec/integration/completion_kit/score_only_expected_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "Score-only run graded against per-row expected_output", type: :model do
+  include ActiveJob::TestHelper
+
+  before do
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_progress)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_response)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_response_update)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_status_header)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_actions)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_sort_toolbar)
+    allow_any_instance_of(CompletionKit::Run).to receive(:broadcast_clear_responses)
+  end
+
+  let(:dataset) do
+    create(:completion_kit_dataset, csv_data: <<~CSV)
+      id,input,actual_output,expected_output
+      "911-carreraT-2019-vin.jpg","VIN plate photo","WP0AA2A98KS103927","WP0AA2A98KS103927"
+      "911-turbo-2011-vin-windshield.jpg","VIN plate photo (degraded)","WP0CD2A91BS773674","WP0CD2A91BS773674"
+      "911-carrera-2014-vin-doorjamb.jpg","VIN plate photo","wp0aa2a97es107665","WP0AA2A97ES107665"
+      "miss-2020.jpg","VIN plate photo","","4S4BSANC7L3241589"
+    CSV
+  end
+
+  let(:metric) do
+    create(:completion_kit_metric, :check,
+      name: "VIN exact match",
+      check_config: { "check_kind" => "equals", "compare_to" => "expected", "trim" => true, "case_sensitive" => false })
+  end
+
+  def build_run
+    CompletionKit::Run.create!(prompt: nil, dataset: dataset, name: "baseline", output_column: "actual_output").tap do |run|
+      run.replace_metrics!([metric.id])
+    end
+  end
+
+  it "grades a blank cell in the graded column as a failed row instead of crashing" do
+    run = build_run
+
+    expect(run.start!).to be(true), -> { "start! failed: #{run.reload.failure_summary}" }
+    perform_enqueued_jobs
+
+    run.reload
+    expect(run.status).to eq("completed")
+    expect(run.responses.count).to eq(4)
+    passes = run.responses.order(:row_index).map { |r| r.reviews.first&.passed }
+    expect(passes).to eq([true, true, true, false])
+    blank_review = run.responses.order(:row_index).last.reviews.first
+    expect(blank_review.ai_feedback).to include("4S4BSANC7L3241589")
+  end
+
+  it "fails the run with a row-scoped summary when a response cannot be built" do
+    run = build_run
+    invalid = CompletionKit::Response.new
+    invalid.errors.add(:base, "boom")
+    allow(run.responses).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(invalid))
+
+    expect(run.start!).to be(false)
+
+    run.reload
+    expect(run.status).to eq("failed")
+    expect(run.failure_summary).to eq("Row 1: boom")
+    expect(run.responses.count).to eq(0)
+  end
+
+  it "fails the run with the bare validation message when the failure is not row-scoped" do
+    run = build_run
+    invalid = CompletionKit::Run.new
+    invalid.errors.add(:base, "run invalid")
+    allow(run).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(invalid))
+
+    expect(run.start!).to be(false)
+
+    run.reload
+    expect(run.status).to eq("failed")
+    expect(run.failure_summary).to eq("run invalid")
+  end
+end


### PR DESCRIPTION
Fixes #99.

- Response presence validation now exempts all judge-only runs (was: only input-data-check runs), so a blank graded cell becomes a real response that fails its per-row expected check with a clear detail.
- `start!` rescues `RecordInvalid` and fails the run with a row-scoped `failure_summary` instead of rolling back to a stuck `pending` + 500.
- `runs_generate` MCP description now says it starts every run, including score-only runs.
- Regression specs: blank-cell run completes with the blank row failed; non-buildable row fails the run with `Row N: ...`; run-level failure keeps the bare message. Suite: 1508 examples, 0 failures, 100/100 coverage.